### PR TITLE
GT: Graph conditions (and bugfixes)

### DIFF
--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTFormattingTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTFormattingTest.xtend
@@ -112,7 +112,7 @@ class GTFormattingTest {
 			'''
 		)
 	}
-	
+
 	@Test
 	def formatRuleWithEmptyBody() {
 		val expected = '''
@@ -217,6 +217,63 @@ class GTFormattingTest {
 				}
 				c: EAnnotation
 				}
+			'''
+		)
+	}
+
+	@Test
+	def formatConditions() {
+		val expected = '''
+			import "http://www.eclipse.org/emf/2002/Ecore"
+			
+			pattern findClassWithoutAnnotation {
+				clazz: EClass
+			}
+			
+			abstract pattern findClassWithAnnotation {
+				clazz: EClass {
+					-eAnnotations -> annotation
+				}
+			
+				annotation: EAnnotation
+			}
+			
+			condition noAnnotation = forbid findClassWithAnnotation
+			
+			condition hasAnnotation = enforce findClassifierWithAnnotation
+			
+			condition orTest = check noAnnotation || check hasAnnotation
+			
+			condition andTest = check noAnnotation && check hasAnnotation
+			
+			condition hasAnnotationConstraint = if findClassWithoutAnnotation then findClassWithoutAnnotation || findClassWithAnnotation
+		'''
+		testFormatting(
+			expected,
+			'''
+				import "http://www.eclipse.org/emf/2002/Ecore"	
+					pattern findClassWithoutAnnotation {clazz: EClass}
+					
+					
+				abstract pattern findClassWithAnnotation {
+				clazz: EClass {-eAnnotations -> annotation}
+				annotation: EAnnotation}
+					
+				condition noAnnotation 
+					= forbid  findClassWithAnnotation
+				condition hasAnnotation  =  enforce  findClassifierWithAnnotation
+				
+				condition  orTest 
+					= check   noAnnotation
+						|| check  hasAnnotation
+							
+					condition  andTest 
+					= check noAnnotation    &&    	check hasAnnotation
+				
+					condition hasAnnotationConstraint  =  if findClassWithoutAnnotation 
+					then findClassWithoutAnnotation  ||  findClassWithAnnotation
+				
+				
 			'''
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTFormattingTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTFormattingTest.xtend
@@ -246,7 +246,7 @@ class GTFormattingTest {
 			
 			condition andTest = check noAnnotation && check hasAnnotation
 			
-			condition hasAnnotationConstraint = if findClassWithoutAnnotation then findClassWithoutAnnotation || findClassWithAnnotation
+			condition hasAnnotationConstraint = if findClassWithoutAnnotation then (findClassWithoutAnnotation || findClassWithAnnotation)
 		'''
 		testFormatting(
 			expected,
@@ -271,7 +271,7 @@ class GTFormattingTest {
 					= check noAnnotation    &&    	check hasAnnotation
 				
 					condition hasAnnotationConstraint  =  if findClassWithoutAnnotation 
-					then findClassWithoutAnnotation  ||  findClassWithAnnotation
+					then (findClassWithoutAnnotation  ||  findClassWithAnnotation)
 				
 				
 			'''

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
@@ -1,7 +1,6 @@
 package org.emoflon.ibex.gt.editor.tests
 
 import org.eclipse.xtext.diagnostics.Diagnostic
-import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.EditorRelation
@@ -318,11 +317,10 @@ class GTParsingAttributesTest extends GTParsingTest {
 			}
 		''')
 		assertFile(file)
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorAttribute,
 			GTValidator.ATTRIBUTE_DUPLICATE_CONDITION,
-			Severity.WARNING,
 			String.format(GTValidator.ATTRIBUTE_DUPLICATE_CONDITION_MESSAGE, 'name', 'clazz', 'twice')
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 class GTParsingAttributesTest extends GTParsingTest {
 	@Test
 	def void validAttributeAssignmentsWithLiteral() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a {
@@ -37,7 +37,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void validAttributeWithLiteral() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -55,7 +55,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void validAttributeWithAttributeExpression() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern findClassAndPackageOfTheSameName {
@@ -74,7 +74,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeWithAttributeExpressionReferencingInvalidNode() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule findClassAndPackageOfTheSameName {
@@ -96,7 +96,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeWithAttributeExpressionReferencingInvalidAttribute() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern r {
@@ -118,7 +118,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void validAttributeWithParameter() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule createClass(name: EString) {
@@ -135,7 +135,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void validAttributeWithParameterFromSuperRule() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern s(name: EString) {
@@ -157,7 +157,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeWithParameterOfInvalidType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule createClass(name: EBoolean) {
@@ -178,7 +178,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeWithLiteralOfWrongType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule createAbstractTestClass {
@@ -206,7 +206,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeWithWrongStringConstant() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule createAbstractTestClass {
@@ -226,7 +226,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfComparisonForIncomparableType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -246,7 +246,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfMultipleAttributeAssignmentsForSameAttribute() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a {
@@ -267,7 +267,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeAssignmentInDeletedNode() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a {
@@ -287,7 +287,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfAttributeConditionInCreatedNode() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a {
@@ -307,7 +307,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void warningIfDuplicateAttributeConditions() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -329,7 +329,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfNoSuchAttributeInMetaModel() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
@@ -1,0 +1,104 @@
+package org.emoflon.ibex.gt.editor.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.emoflon.ibex.gt.editor.gT.GTPackage
+import org.emoflon.ibex.gt.editor.validation.GTValidator
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * JUnit tests for conditions.
+ */
+@RunWith(XtextRunner)
+@InjectWith(GTInjectorProvider)
+class GTParsingConditionsTest extends GTParsingTest {
+
+	@Test
+	def void errorIfConditionReferencesRule() {
+		val file = parse('''
+			import "«ecoreImport»"
+			
+			rule a {
+				++ object: EObject
+			}
+			
+			rule b {
+				++ object: EObject
+			}
+			
+			condition constraintCond = if a then (a || b) 
+			condition enforceCond = enforce a
+			condition forbidCond = forbid a
+		''')
+		assertFile(file, 2)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorConstraint,
+			GTValidator.CONDITION_PATTERN_INVALID_RULE,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_RULE_MESSAGE, 'a')
+		)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorConstraint,
+			GTValidator.CONDITION_PATTERN_INVALID_RULE,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_RULE_MESSAGE, 'b')
+		)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorEnforce,
+			GTValidator.CONDITION_PATTERN_INVALID_RULE,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_RULE_MESSAGE, 'a')
+		)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorForbid,
+			GTValidator.CONDITION_PATTERN_INVALID_RULE,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_RULE_MESSAGE, 'a')
+		)
+	}
+
+	@Test
+	def void errorIfConditionReferencesParameterizedPattern() {
+		val file = parse('''
+			import "«ecoreImport»"
+			
+			pattern a(i: EInt) {
+				object: EObject
+			}
+			
+			pattern b(i: EInt) {
+				object: EObject
+			}
+			
+			condition constraintCond = if a then (a || b) 
+			condition enforceCond = enforce a
+			condition forbidCond = forbid a
+		''')
+		assertFile(file, 2)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorConstraint,
+			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'a')
+		)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorConstraint,
+			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'b')
+		)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorEnforce,
+			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'a')
+		)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorForbid,
+			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'a')
+		)
+	}
+}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingImportsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingImportsTest.xtend
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith
 class GTParsingImportsTest extends GTParsingTest {
 	@Test
 	def void errorIfNoImport() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			pattern a {
 				object: EObject
 			}
@@ -32,7 +32,7 @@ class GTParsingImportsTest extends GTParsingTest {
 
 	@Test
 	def void warningIfDuplicateImport() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			import "«ecoreImport»"
 			
@@ -53,7 +53,7 @@ class GTParsingImportsTest extends GTParsingTest {
 	@Test
 	def void errorIfInvalidImport() {
 		val importName = 'test.ecore'
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«importName»"
 			
 			pattern a {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingImportsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingImportsTest.xtend
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.gt.editor.tests
 
-import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.GTPackage
@@ -41,11 +40,10 @@ class GTParsingImportsTest extends GTParsingTest {
 			}
 		''')
 		assertValidResource(file)
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorImport,
 			GTValidator.IMPORT_DUPLICATE,
-			Severity.WARNING,
 			String.format(GTValidator.IMPORT_DUPLICATE_MESSAGE, ecoreImport, 'twice')
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingNodesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingNodesTest.xtend
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith
 class GTParsingNodesTest extends GTParsingTest {
 	@Test
 	def void validContextNodes() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -34,7 +34,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void validCreateAndDeleteNodes() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a() {
@@ -51,7 +51,7 @@ class GTParsingNodesTest extends GTParsingTest {
 	@Test
 	def void warningIfNodeNameStartsWithCapital() {
 		val nodeName = "AnInvalidNodeName"
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -71,7 +71,7 @@ class GTParsingNodesTest extends GTParsingTest {
 	@Test
 	def void errorIfNodeNameBlacklisted() {
 		val nodeName = 'class'
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -90,7 +90,7 @@ class GTParsingNodesTest extends GTParsingTest {
 	@Test
 	def void warningIfNodeNameContainsUndercores() {
 		val nodeName = 'the_e_Object'
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -110,7 +110,7 @@ class GTParsingNodesTest extends GTParsingTest {
 	@Test
 	def void errorIfMultipleNodesWithTheSameName() {
 		val nodeName = 'a'
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -130,7 +130,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfNoSuchNodeType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a() {
@@ -148,7 +148,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfCreatedNodeHasAbstractType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a() {
@@ -166,7 +166,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfNodeOfSameNameAsParameter() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule a(clazz: EString) {
@@ -184,7 +184,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void validNodeTypeChange() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern super {
@@ -201,7 +201,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfInvalidNodeTypeChange() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			pattern super {
 				c: EDataType
@@ -224,7 +224,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void validNodeOperatorChange() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			rule super {
 				++ c: EClass
@@ -240,7 +240,7 @@ class GTParsingNodesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfInvalidNodeOperatorChange() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern super {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingNodesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingNodesTest.xtend
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.gt.editor.tests
 
-import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.EditorOperator
@@ -59,11 +58,10 @@ class GTParsingNodesTest extends GTParsingTest {
 			}
 		''')
 		assertFile(file)
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorNode,
 			GTValidator.NAME_EXPECT_LOWER_CASE,
-			Severity.WARNING,
 			String.format(GTValidator.NODE_NAME_STARTS_WITH_LOWER_CASE_MESSAGE, nodeName)
 		)
 	}
@@ -98,11 +96,10 @@ class GTParsingNodesTest extends GTParsingTest {
 			}
 		''')
 		assertFile(file)
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorNode,
 			GTValidator.NAME_EXPECT_CAMEL_CASE,
-			Severity.WARNING,
 			String.format(GTValidator.NODE_NAME_CONTAINS_UNDERSCORES_MESSAGE, nodeName)
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingParametersTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingParametersTest.xtend
@@ -1,7 +1,6 @@
 package org.emoflon.ibex.gt.editor.tests
 
 import org.eclipse.xtext.diagnostics.Diagnostic
-import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.GTPackage
@@ -166,11 +165,10 @@ class GTParsingParametersTest extends GTParsingTest {
 				}
 			}
 		''')
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorParameter,
 			GTValidator.NAME_EXPECT_LOWER_CASE,
-			Severity.WARNING,
 			String.format(GTValidator.PARAMETER_NAME_STARTS_WITH_LOWER_CASE_MESSAGE, 'ClassName')
 		)
 	}
@@ -186,11 +184,10 @@ class GTParsingParametersTest extends GTParsingTest {
 				}
 			}
 		''')
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorParameter,
 			GTValidator.NAME_EXPECT_CAMEL_CASE,
-			Severity.WARNING,
 			String.format(GTValidator.PARAMETER_NAME_CONTAINS_UNDERSCORES_MESSAGE, 'class_name')
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingParametersTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingParametersTest.xtend
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 class GTParsingParametersTest extends GTParsingTest {
 	@Test
 	def void validRuleWithNoParameters() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a() {
@@ -32,7 +32,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void validRuleWithOneParameter() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a(name: EString) {
@@ -45,7 +45,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void validRuleWithThreeParameters() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a(age: EDouble, name: EString, isMale: EBoolean) {
@@ -62,7 +62,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void errorIfRuleWithInvalidParameterType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a(age: EClass) {
@@ -80,7 +80,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void errorIfParameterListEndsWithComma() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a(age: int,) {
@@ -98,7 +98,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void errorIfParameterListWithNoColons() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern A(age EInt, name EString, isMale EBoolean) {
@@ -118,7 +118,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void errorIfParameterListContainsSemicolons() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "http://www.eclipse.org/emf/2002/Ecore"
 			
 			pattern a(age: EInt; name: EString; isMale: EBoolean) {
@@ -136,7 +136,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void errorIfParameterNameBlacklisted() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "http://www.eclipse.org/emf/2002/Ecore"
 			
 			rule createClass(class: EString) {
@@ -155,7 +155,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void warningIfParameterNameStartsWithCapital() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "http://www.eclipse.org/emf/2002/Ecore"
 			
 			import "http://www.eclipse.org/emf/2002/Ecore"
@@ -177,7 +177,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void warningIfParameterNameContainsUnderscores() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "http://www.eclipse.org/emf/2002/Ecore"
 			
 			rule createClass(class_name: EString) {
@@ -197,7 +197,7 @@ class GTParsingParametersTest extends GTParsingTest {
 
 	@Test
 	def void errorIfMultipleParametersWithTheSameName() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "http://www.eclipse.org/emf/2002/Ecore"
 			
 			rule createClass(name: EString, name: EChar) {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementFlatteningTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementFlatteningTest.xtend
@@ -18,7 +18,7 @@ class GTParsingPatternRefinementFlatteningTest extends GTParsingTest {
 
 	@Test
 	def void validFlattening() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			abstract pattern findClassifierWithAnnotation(name: EString) {
@@ -60,7 +60,7 @@ class GTParsingPatternRefinementFlatteningTest extends GTParsingTest {
 
 	@Test
 	def void validFlatteningWithAttributes() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern findClass(name: EString) {
@@ -96,7 +96,7 @@ class GTParsingPatternRefinementFlatteningTest extends GTParsingTest {
 
 	@Test
 	def void validFlatteningOfReferences() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			abstract rule findClassifierWithAnnotation {
@@ -138,7 +138,7 @@ class GTParsingPatternRefinementFlatteningTest extends GTParsingTest {
 
 	@Test
 	def void errorForFlatteningRuleWithConflictingAttributeAssignments() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule renameClass(oldName: EString) {
@@ -167,7 +167,7 @@ class GTParsingPatternRefinementFlatteningTest extends GTParsingTest {
 
 	@Test
 	def void errorForFlatteningRuleWithInconsistentParameterDeclarations() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern findClass(interface: EBoolean, name: EString) {
@@ -192,7 +192,7 @@ class GTParsingPatternRefinementFlatteningTest extends GTParsingTest {
 
 	@Test
 	def void errorForInvalidOperators() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule createAnnotation {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementTest.xtend
@@ -3,7 +3,6 @@ package org.emoflon.ibex.gt.editor.tests
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.GTPackage
-import org.emoflon.ibex.gt.editor.scoping.GTLinkingDiagnosticMessageProvider
 import org.emoflon.ibex.gt.editor.validation.GTValidator
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +15,7 @@ import org.junit.runner.RunWith
 class GTParsingPatternRefinementTest extends GTParsingTest {
 	@Test
 	def void validIfEmptyRuleBodyAndMultipleRefinement() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -35,7 +34,7 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 
 	@Test
 	def void errorForSelfRefinement() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a
@@ -47,14 +46,14 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTLinkingDiagnosticMessageProvider.RULE_SUPER_RULE_NOT_FOUND,
-			String.format(GTLinkingDiagnosticMessageProvider.RULE_SUPER_RULE_NOT_FOUND_MESSAGE, 'a')
+			GTValidator.PATTERN_SUPER_PATTERNS_INVALID,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_INVALID_MESSAGE, 'a', 'a')
 		)
 	}
 
 	@Test
 	def void errorIfLoopinRulesRefinementHierarchyLevel1() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a
@@ -71,14 +70,14 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTLinkingDiagnosticMessageProvider.RULE_SUPER_RULE_NOT_FOUND,
-			String.format(GTLinkingDiagnosticMessageProvider.RULE_SUPER_RULE_NOT_FOUND_MESSAGE, 'a')
+			GTValidator.PATTERN_SUPER_PATTERNS_INVALID,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_INVALID_MESSAGE, 'a', 'b')
 		)
 	}
 
 	@Test
 	def void errorIfLoopinRulesRefinementHierarchyLevel2() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a
@@ -100,14 +99,14 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTLinkingDiagnosticMessageProvider.RULE_SUPER_RULE_NOT_FOUND,
-			String.format(GTLinkingDiagnosticMessageProvider.RULE_SUPER_RULE_NOT_FOUND_MESSAGE, 'a')
+			GTValidator.PATTERN_SUPER_PATTERNS_INVALID,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_INVALID_MESSAGE, 'a', 'b')
 		)
 	}
 
 	@Test
 	def void errorIfNoDistinctSuperRules() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a {
@@ -128,7 +127,7 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 
 	@Test
 	def void errorIfConclictingParameterDeclarationsBetweenSuperRules() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern s1(name: EString) {
@@ -156,7 +155,7 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 
 	@Test
 	def void errorIfConclictingParameterDeclarationsRuleAndSuperRule() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern s(name: EString) {
@@ -180,7 +179,7 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 
 	@Test
 	def void errorIfConflictingAttributeAssignments() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule renameClassToTest1 {
@@ -209,7 +208,7 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 
 	@Test
 	def void validIfNoConflictBetweenAttributeAssignments() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule renameClassToTest1 {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementTest.xtend
@@ -120,8 +120,8 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.RULE_SUPER_RULES_DUPLICATE,
-			String.format(GTValidator.RULE_SUPER_RULES_DUPLICATE_MESSAGE, 'b')
+			GTValidator.PATTERN_SUPER_PATTERNS_DUPLICATE,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_DUPLICATE_MESSAGE, 'b')
 		)
 	}
 
@@ -147,8 +147,8 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.RULE_REFINEMENT_INVALID_PARAMETER,
-			String.format(GTValidator.RULE_REFINEMENT_INVALID_PARAMETER_MESSAGE, 'r', 'name',
+			GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER,
+			String.format(GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER_MESSAGE, 'r', 'name',
 				GTValidator.concatNames(#['EBoolean', 'EString']))
 		)
 	}
@@ -171,8 +171,8 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.RULE_REFINEMENT_INVALID_PARAMETER,
-			String.format(GTValidator.RULE_REFINEMENT_INVALID_PARAMETER_MESSAGE, 'r', 'name',
+			GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER,
+			String.format(GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER_MESSAGE, 'r', 'name',
 				GTValidator.concatNames(#['EBoolean', 'EString']))
 		)
 	}
@@ -201,8 +201,8 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.RULE_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT,
-			String.format(GTValidator.RULE_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE, 'renameClass', 'clazz')
+			GTValidator.PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT,
+			String.format(GTValidator.PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE, 'renameClass', 'clazz')
 		)
 	}
 

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternsTest.xtend
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.gt.editor.tests
 
-import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.GTPackage
@@ -95,11 +94,10 @@ class GTParsingPatternsTest extends GTParsingTest {
 			}
 		''')
 		assertFile(file)
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
 			GTValidator.NAME_EXPECT_CAMEL_CASE,
-			Severity.WARNING,
 			String.format(GTValidator.PATTERN_NAME_CONTAINS_UNDERSCORES_MESSAGE, ruleName)
 		)
 	}
@@ -134,11 +132,10 @@ class GTParsingPatternsTest extends GTParsingTest {
 			}
 		''')
 		assertFile(file)
-		assertValidationIssues(
+		assertValidationWarnings(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
 			GTValidator.NAME_EXPECT_LOWER_CASE,
-			Severity.WARNING,
 			String.format(GTValidator.PATTERN_NAME_STARTS_WITH_LOWER_CASE_MESSAGE, ruleName)
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternsTest.xtend
@@ -26,8 +26,8 @@ class GTParsingPatternsTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.RULE_EMPTY,
-			String.format(GTValidator.RULE_EMPTY_MESSAGE, 'a')
+			GTValidator.PATTERN_EMPTY,
+			String.format(GTValidator.PATTERN_EMPTY_MESSAGE, 'a')
 		)
 	}
 
@@ -79,8 +79,8 @@ class GTParsingPatternsTest extends GTParsingTest {
 			file,
 			GTPackage.eINSTANCE.editorPattern,
 			GTValidator.NAME_EXPECT_UNIQUE,
-			String.format(GTValidator.RULE_NAME_MULTIPLE_DECLARATIONS_MESSAGE, "a", "twice"),
-			String.format(GTValidator.RULE_NAME_MULTIPLE_DECLARATIONS_MESSAGE, "b", "3 times")
+			String.format(GTValidator.PATTERN_NAME_MULTIPLE_DECLARATIONS_MESSAGE, "a", "twice"),
+			String.format(GTValidator.PATTERN_NAME_MULTIPLE_DECLARATIONS_MESSAGE, "b", "3 times")
 		)
 	}
 
@@ -100,7 +100,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 			GTPackage.eINSTANCE.editorPattern,
 			GTValidator.NAME_EXPECT_CAMEL_CASE,
 			Severity.WARNING,
-			String.format(GTValidator.RULE_NAME_CONTAINS_UNDERSCORES_MESSAGE, ruleName)
+			String.format(GTValidator.PATTERN_NAME_CONTAINS_UNDERSCORES_MESSAGE, ruleName)
 		)
 	}
 
@@ -119,7 +119,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 			file,
 			GTPackage.eINSTANCE.editorPattern,
 			GTValidator.NAME_BLACKLISTED,
-			String.format(GTValidator.RULE_NAME_FORBIDDEN_MESSAGE, ruleName)
+			String.format(GTValidator.PATTERN_NAME_FORBIDDEN_MESSAGE, ruleName)
 		)
 	}
 
@@ -139,7 +139,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 			GTPackage.eINSTANCE.editorPattern,
 			GTValidator.NAME_EXPECT_LOWER_CASE,
 			Severity.WARNING,
-			String.format(GTValidator.RULE_NAME_STARTS_WITH_LOWER_CASE_MESSAGE, ruleName)
+			String.format(GTValidator.PATTERN_NAME_STARTS_WITH_LOWER_CASE_MESSAGE, ruleName)
 		)
 	}
 

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternsTest.xtend
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith
 class GTParsingPatternsTest extends GTParsingTest {
 	@Test
 	def void errorIfEmptyRuleBody() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a() {}
@@ -33,7 +33,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 
 	@Test
 	def void validModifiers() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			abstract pattern a() {
@@ -51,7 +51,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 
 	@Test
 	def void errorIfRuleNameDuplicates() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern a() {
@@ -87,7 +87,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 	@Test
 	def void warningIfRuleNameContainsUnderscores() {
 		val ruleName = 'get_an_e_Object'
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern «ruleName» {
@@ -107,7 +107,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 	@Test
 	def void errorIfRuleNameInBlacklist() {
 		val ruleName = "hashCode"
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern «ruleName» {
@@ -126,7 +126,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 	@Test
 	def void warningIfRuleNameStartsWithCapital() {
 		val ruleName = "AnInvalidName"
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern «ruleName» {
@@ -145,7 +145,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 
 	@Test
 	def void errorIfPatternContainsCreatedElement() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern test {
@@ -163,7 +163,7 @@ class GTParsingPatternsTest extends GTParsingTest {
 
 	@Test
 	def void errorIfRuleContainsNoCreatedOrDeletedElement() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule test {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingReferencesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingReferencesTest.xtend
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith
 class GTParsingReferencesTest extends GTParsingTest {
 	@Test
 	def void validContextReference() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern findClass() {
@@ -38,7 +38,7 @@ class GTParsingReferencesTest extends GTParsingTest {
 
 	@Test
 	def void validCreateAndDeleteReferences() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule createAndDeleteClass() {
@@ -59,7 +59,7 @@ class GTParsingReferencesTest extends GTParsingTest {
 
 	@Test
 	def void validUseOfNodesFromSuperRules() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			rule s {
@@ -85,7 +85,7 @@ class GTParsingReferencesTest extends GTParsingTest {
 	@Ignore("Needs Causes Exception, seems to be a scoping problem")
 	@Test
 	def void errorIfNoSuchReferenceTypeInMetaModel() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern findClass() {
@@ -107,7 +107,7 @@ class GTParsingReferencesTest extends GTParsingTest {
 
 	@Test
 	def void errorIfReferenceHasWrongTargetType() {
-		val file = parseHelper.parse('''
+		val file = parse('''
 			import "«ecoreImport»"
 			
 			pattern findClass() {
@@ -246,7 +246,7 @@ class GTParsingReferencesTest extends GTParsingTest {
 	def EditorGTFile parseNodesWithReference(String sourceNodeOperator, String referenceOperator,
 		String targetNodeOperator) {
 		val type = if(sourceNodeOperator + referenceOperator + targetNodeOperator == '') 'pattern' else 'rule'
-		parseHelper.parse('''
+		parse('''
 			import "«ecoreImport»"
 			
 			«type» r1 {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingTest.xtend
@@ -13,13 +13,13 @@ import org.eclipse.xtext.testing.validation.ValidationTestHelper
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorAttributeExpression
 import org.emoflon.ibex.gt.editor.gT.EditorGTFile
-import org.emoflon.ibex.gt.editor.gT.EditorReference
 import org.emoflon.ibex.gt.editor.gT.EditorLiteralExpression
 import org.emoflon.ibex.gt.editor.gT.EditorNode
 import org.emoflon.ibex.gt.editor.gT.EditorOperator
 import org.emoflon.ibex.gt.editor.gT.EditorParameter
 import org.emoflon.ibex.gt.editor.gT.EditorParameterExpression
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
+import org.emoflon.ibex.gt.editor.gT.EditorReference
 import org.emoflon.ibex.gt.editor.gT.EditorRelation
 import org.junit.Assert
 import org.junit.runner.RunWith
@@ -59,12 +59,15 @@ abstract class GTParsingTest {
 	}
 
 	def void assertValidationErrors(EditorGTFile file, EClass objectType, String code, String... messages) {
-		messages.forEach[this.validationHelper.assertError(file, objectType, code, it)]
+		messages.forEach [
+			this.validationHelper.assertError(file, objectType, code, it)
+		]
 	}
 
-	def void assertValidationIssues(EditorGTFile file, EClass objectType, String code, Severity severity,
-		String... messages) {
-		messages.forEach[this.validationHelper.assertIssue(file, objectType, code, severity, it)]
+	def void assertValidationWarnings(EditorGTFile file, EClass objectType, String code, String... messages) {
+		messages.forEach [
+			this.validationHelper.assertIssue(file, objectType, code, Severity.WARNING, it)
+		]
 	}
 
 	static def void assertValidResource(EditorGTFile file) {

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingTest.xtend
@@ -2,7 +2,9 @@ package org.emoflon.ibex.gt.editor.tests
 
 import com.google.inject.Inject
 import java.util.Map
+import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
@@ -35,6 +37,14 @@ abstract class GTParsingTest {
 	protected ParseHelper<EditorGTFile> parseHelper
 
 	@Inject extension private ValidationTestHelper validationHelper
+
+	def parse(CharSequence s) {
+		return parseHelper.parse(
+			s,
+			URI.createPlatformResourceURI("/TestProject/src/Test.gt", true),
+			new ResourceSetImpl
+		)
+	}
 
 	def void assertValid(EditorGTFile file) {
 		Assert.assertNotNull(file)

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/contentassist/GTProposalProvider.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/contentassist/GTProposalProvider.xtend
@@ -20,7 +20,7 @@ class GTProposalProvider extends AbstractGTProposalProvider {
 		ICompletionProposalAcceptor acceptor) {
 		super.completeEditorImport_Name(model, assignment, context, acceptor)
 
-		val gtFile = model.eContainer as EditorGTFile
+		val gtFile = if(model instanceof EditorGTFile) model else model.eContainer as EditorGTFile
 		val currentImports = gtFile.imports.map[it.name].toList
 		WorkspaceSearch.getEcoreURIsInWorkspace(currentImports).forEach [
 			acceptor.accept(createCompletionProposal('''"«it»"''', context))

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/outline/GTOutlineTreeProvider.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/outline/GTOutlineTreeProvider.xtend
@@ -8,6 +8,7 @@ import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 import org.eclipse.xtext.ui.IImageHelper
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
 import org.emoflon.ibex.gt.editor.gT.EditorPatternType
+import org.emoflon.ibex.gt.editor.gT.EditorCondition
 
 /**
  * Customization of the default outline structure.
@@ -19,10 +20,24 @@ class GTOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	private IImageHelper imageHelper
 
 	override _createNode(IOutlineNode parentNode, EObject modelElement) {
-		if (modelElement instanceof EditorPattern) {
+		if (modelElement instanceof EditorPattern || modelElement instanceof EditorCondition) {
 			super._createNode(parentNode, modelElement)
 		}
 		return
+	}
+
+	/**
+	 * Avoid display patterns as expandable nodes.
+	 */
+	def _isLeaf(EditorPattern pattern) {
+		return true;
+	}
+
+	/**
+	 * Avoid display conditions as expandable nodes.
+	 */
+	def _isLeaf(EditorCondition condition) {
+		return true;
 	}
 
 	/**
@@ -39,17 +54,13 @@ class GTOutlineTreeProvider extends DefaultOutlineTreeProvider {
 		return text
 	}
 
+	/**
+	 * Customize the image for the pattern/rule.
+	 */
 	def _image(EditorPattern pattern) {
 		if (pattern.type == EditorPatternType.RULE) {
 			return imageHelper.getImage('gt-rule.gif')
 		}
 		return imageHelper.getImage('gt-pattern.gif')
-	}
-
-	/**
-	 * Avoid display as expandable nodes.
-	 */
-	def boolean _isLeaf(EditorPattern pattern) {
-		return true;
 	}
 }

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/quickfix/GTQuickfixProvider.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/quickfix/GTQuickfixProvider.xtend
@@ -64,9 +64,9 @@ class GTQuickfixProvider extends DefaultQuickfixProvider {
 	}
 
 	/**
-	 * Removes duplicates in super patterns.
+	 * Removes the duplicate super pattern(s).
 	 */
-	@Fix(GTValidator.RULE_SUPER_RULES_DUPLICATE)
+	@Fix(GTValidator.PATTERN_SUPER_PATTERNS_DUPLICATE)
 	def removeSuperRule(Issue issue, IssueResolutionAcceptor acceptor) {
 		GTPatternQuickfixes.makeSuperPatternsDistinct(issue, acceptor)
 	}

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
@@ -24,6 +24,7 @@ import org.emoflon.ibex.gt.editor.gT.EditorParameterExpression
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
 import org.emoflon.ibex.gt.editor.gT.EditorReference
 import org.emoflon.ibex.gt.editor.gT.EditorRelation
+import org.emoflon.ibex.gt.editor.utils.GTEditorPatternUtils
 import org.emoflon.ibex.gt.editor.utils.GTFlattener
 
 /**
@@ -294,6 +295,15 @@ class GTPlantUMLGenerator {
 	 * Returns the PlantUML code for the visualization of the refinement hierarchy of the given patterns.
 	 */
 	public static def String visualizePatternHierarchy(EList<EditorPattern> patterns) {
+		val allPatterns = new HashSet(patterns)
+		for (p : patterns) {
+			for (s : GTEditorPatternUtils.getAllSuperPatterns(p)) {
+				if (!allPatterns.contains(s)) {
+					allPatterns.add(s)
+				}
+			}
+		}
+
 		'''
 			«commonLayoutSettings»
 			
@@ -303,11 +313,11 @@ class GTPlantUMLGenerator {
 				ArrowColor Black
 			}
 			
-			«FOR pattern : patterns»
+			«FOR pattern : allPatterns»
 				«IF pattern.abstract»abstract «ENDIF»class "«pattern.name»" «link(pattern)»
 			«ENDFOR»
 			
-			«FOR pattern : patterns»
+			«FOR pattern : allPatterns»
 				«FOR sup: pattern.superPatterns»
 					«IF sup.name !== null»
 						"«pattern.name»" -up-|> "«sup.name»"

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
@@ -1,13 +1,24 @@
 package org.emoflon.ibex.gt.editor.ui.visualization
 
+import java.util.HashSet
+import java.util.Set
+
 import org.eclipse.emf.common.util.EList
+import org.emoflon.ibex.gt.editor.gT.EditorAndCondition
+import org.emoflon.ibex.gt.editor.gT.EditorConditionReference
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorAttributeExpression
+import org.emoflon.ibex.gt.editor.gT.EditorConditionExpression
+import org.emoflon.ibex.gt.editor.gT.EditorConstraint
+import org.emoflon.ibex.gt.editor.gT.EditorEnforce
 import org.emoflon.ibex.gt.editor.gT.EditorEnumExpression
 import org.emoflon.ibex.gt.editor.gT.EditorExpression
+import org.emoflon.ibex.gt.editor.gT.EditorForbid
 import org.emoflon.ibex.gt.editor.gT.EditorLiteralExpression
+import org.emoflon.ibex.gt.editor.gT.EditorNegativeCondition
 import org.emoflon.ibex.gt.editor.gT.EditorNode
 import org.emoflon.ibex.gt.editor.gT.EditorOperator
+import org.emoflon.ibex.gt.editor.gT.EditorOrCondition
 import org.emoflon.ibex.gt.editor.gT.EditorParameter
 import org.emoflon.ibex.gt.editor.gT.EditorParameterExpression
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
@@ -37,6 +48,7 @@ class GTPlantUMLGenerator {
 	 */
 	public static def String visualizePattern(EditorPattern pattern) {
 		val flattenedPattern = new GTFlattener(pattern).getFlattenedPattern
+		val nodeNamesInFlattenedPattern = flattenedPattern.nodes.map[it.name]
 		'''
 			«commonLayoutSettings»
 			
@@ -50,24 +62,58 @@ class GTPlantUMLGenerator {
 				FontColor White
 			}
 			
-			«FOR node : flattenedPattern.nodes»
-				class «nodeName(node)» <<«nodeSkin(node)»>> {
+			«IF pattern.conditions.isEmpty»
+				«visualizeGraph(flattenedPattern)»
+			«ELSE»
+				namespace «pattern.name» {
+					«visualizeGraph(flattenedPattern)»
+				}
+				
+				«FOR p : getConditionPatterns(pattern)»
+					«val f = new GTFlattener(p).getFlattenedPattern»
+					namespace «p.name» #EEEEEE {
+						«visualizeGraph(f)»
+					}
+					
+					«FOR node : f.nodes»
+						«IF nodeNamesInFlattenedPattern.contains(node.name)»
+							"«pattern.name».«nodeName(node)»" #--# "«p.name».«nodeName(node)»"
+						«ENDIF»
+					«ENDFOR»
+				«ENDFOR»
+			«ENDIF»
+			
+			«IF !pattern.conditions.isEmpty»
+				legend bottom
+					«getConditionString(pattern)»
+				endlegend
+			«ENDIF»
+			
+			center footer
+				= «pattern.name»
+				«signature(flattenedPattern)»
+			end footer
+		'''
+	}
+
+	/**
+	 * Visualizes the nodes and edges. 
+	 */
+	private static def String visualizeGraph(EditorPattern pattern) {
+		'''
+			«FOR node : pattern.nodes»
+				class "«nodeName(node)»" <<«nodeSkin(node)»>> {
 					«FOR attr: node.attributes»
 						«attributeConstraint(attr)»
 					«ENDFOR»
 				}
 			«ENDFOR»
 			
-			«FOR node : flattenedPattern.nodes»
+			«FOR node : pattern.nodes»
 				«FOR reference : node.references»
-					«nodeName(node)» -[#«referenceColor(reference)»]-> «nodeName(reference.target)»: «referenceLabel(reference)»
+					"«nodeName(node)»" -[#«referenceColor(reference)»]-> "«nodeName(reference.target)»": «referenceLabel(reference)»
 				«ENDFOR»
 			«ENDFOR»
-			
-			center footer
-				= «pattern.name»
-				«org.emoflon.ibex.gt.editor.ui.visualization.GTPlantUMLGenerator.signature(flattenedPattern)»
-			end footer
 		'''
 	}
 
@@ -76,10 +122,10 @@ class GTPlantUMLGenerator {
 	 */
 	private static def String nodeName(EditorNode node) {
 		if (node === null) {
-			return '"?"'
+			return '?'
 		}
 		val type = if(node.type === null) '?' else node.type.name
-		'''"«node.name»: «type»"'''
+		'''«node.name»: «type»'''
 	}
 
 	/**
@@ -147,6 +193,86 @@ class GTPlantUMLGenerator {
 			return '''«expression.parameter.name»'''
 		}
 		return '''«expression.toString»'''
+	}
+
+	/**
+	 * Extracts the patterns from the conditions of the pattern.
+	 */
+	private static def Set<EditorPattern> getConditionPatterns(EditorPattern pattern) {
+		val patterns = new HashSet
+		pattern.conditions.forEach [
+			patterns.addAll(getConditionPatterns(it.expression))
+		]
+		return patterns
+	}
+
+	/**
+	 * Extracts the patterns from a single condition. 
+	 */
+	private static def Set<EditorPattern> getConditionPatterns(EditorConditionExpression condition) {
+		val patterns = new HashSet
+
+		if (condition instanceof EditorAndCondition) {
+			patterns.addAll(getConditionPatterns(condition.left))
+			patterns.addAll(getConditionPatterns(condition.right))
+		}
+		if (condition instanceof EditorOrCondition) {
+			patterns.addAll(getConditionPatterns(condition.left))
+			patterns.addAll(getConditionPatterns(condition.right))
+		}
+		if (condition instanceof EditorNegativeCondition) {
+			patterns.addAll(getConditionPatterns(condition.expression))
+		}
+
+		if (condition instanceof EditorConditionReference) {
+			patterns.addAll(getConditionPatterns(condition.condition.expression))
+		}
+		if (condition instanceof EditorConstraint) {
+			patterns.add(condition.premise)
+			patterns.addAll(condition.conclusions)
+		}
+		if (condition instanceof EditorEnforce) {
+			patterns.add(condition.pattern)
+		}
+		if (condition instanceof EditorForbid) {
+			patterns.add(condition.pattern)
+		}
+		return patterns
+	}
+
+	/**
+	 * Prints the conditions of the pattern.
+	 */
+	private static def String getConditionString(EditorPattern pattern) {
+		'''«FOR c : pattern.conditions SEPARATOR ' **&&** '»«getConditionString(c.expression)»«ENDFOR»'''
+	}
+
+	/**
+	 * Print the condition.
+	 */
+	private static def String getConditionString(EditorConditionExpression condition) {
+		if (condition instanceof EditorAndCondition) {
+			return '''(«getConditionString(condition.left)» **&&** «getConditionString(condition.right)»)'''
+		}
+		if (condition instanceof EditorOrCondition) {
+			return '''(«getConditionString(condition.left)» **||** «getConditionString(condition.right)»)'''
+		}
+		if (condition instanceof EditorNegativeCondition) {
+			return '''**!**«getConditionString(condition.expression)»'''
+		}
+
+		if (condition instanceof EditorConditionReference) {
+			return '''«getConditionString(condition.condition.expression)»'''
+		}
+		if (condition instanceof EditorConstraint) {
+			return '''**if** «condition.premise.name» **then** «FOR c : condition.conclusions»«c.name»«ENDFOR»'''
+		}
+		if (condition instanceof EditorEnforce) {
+			return '''**enforce** «condition.pattern.name»'''
+		}
+		if (condition instanceof EditorForbid) {
+			return '''**forbid** «condition.pattern.name»'''
+		}
 	}
 
 	/**

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
@@ -5,7 +5,8 @@ generate gT "http://www.emoflon.org/ibex/gt/editor/GT"
 
 EditorGTFile:
 	(imports+=EditorImport)*
-	(patterns+=EditorPattern)*;
+	(patterns+=EditorPattern)*
+	(conditions+=EditorCondition)*;
 
 EditorImport:
 	'import' name=STRING;
@@ -80,3 +81,34 @@ EditorParameterExpression:
 	// References
 EditorReference:
 	(operator=OperatorInEditor)? '-' type=[ecore::EReference] '->' target=[EditorNode];
+
+	// Graph Conditions
+EditorCondition:
+	'condition' name=ID
+	'=' condition=EditorConditionExpression;
+
+EditorConditionExpression:
+	EditorOr;
+
+EditorOr returns EditorConditionExpression:
+	EditorAnd ({EditorOr.left=current} '||' right=EditorAnd)*;
+
+EditorAnd returns EditorConditionExpression:
+	EditorNegation ({EditorAnd.left=current} '&&' right=EditorNegation)*;
+
+EditorNegation returns EditorConditionExpression:
+	'!' EditorBasicExpression |
+	EditorBasicExpression;
+
+EditorBasicExpression returns EditorConditionExpression:
+	EditorPatternCondition |
+	'(' EditorOr ')';
+
+EditorPatternCondition returns EditorConditionExpression:
+	{EditorEnforce}
+	'enforce' pattern=[EditorPattern] |
+	{EditorForbid}
+	'forbid' pattern=[EditorPattern] |
+	{EditorConstraint}
+	'check' premise=[EditorPattern]
+	'implies' conclusions+=[EditorPattern] ('||' conditions+=[EditorPattern])*;

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
@@ -19,7 +19,8 @@ EditorPattern:
 	('refines' superPatterns+=[EditorPattern] (',' superPatterns+=[EditorPattern])*)?
 	('{'
 	(nodes+=EditorNode)*
-	'}')?;
+	'}')?
+	('when' conditions+=[EditorCondition] ('&&' conditions+=[EditorCondition])*)?;
 
 enum EditorPatternType:
 	PATTERN='pattern' |

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
@@ -86,30 +86,23 @@ EditorReference:
 	// Graph Conditions
 EditorCondition:
 	'condition' name=ID
-	'=' condition=EditorConditionExpression;
+	'=' expression=EditorConditionExpression;
 
 EditorConditionExpression:
-	EditorOr;
+	EditorOrCondition;
 
-EditorOr returns EditorConditionExpression:
-	EditorAnd ({EditorOr.left=current} '||' right=EditorAnd)*;
+EditorOrCondition returns EditorConditionExpression:
+	EditorAndCondition ({EditorOrCondition.left=current} '||' right=EditorAndCondition)*;
 
-EditorAnd returns EditorConditionExpression:
-	EditorNegation ({EditorAnd.left=current} '&&' right=EditorNegation)*;
+EditorAndCondition returns EditorConditionExpression:
+	EditorNegation ({EditorAndCondition.left=current} '&&' right=EditorNegation)*;
 
 EditorNegation returns EditorConditionExpression:
-	EditorBasicExpression |
-	EditorNegativeExpression;
-
-EditorBasicExpression returns EditorConditionExpression:
-	EditorSimpleCondition |
-	'(' EditorOr ')';
-
-EditorNegativeExpression returns EditorConditionExpression:
-	'!' (EditorSimpleCondition |
-	'(' EditorOr ')');
+	{EditorNegativeCondition} '!' expression=EditorSimpleCondition |
+	EditorSimpleCondition;
 
 EditorSimpleCondition returns EditorConditionExpression:
+	'(' EditorOrCondition ')' |
 	{EditorConditionReference}
 	'check' condition=[EditorCondition] |
 	{EditorEnforce}
@@ -117,4 +110,5 @@ EditorSimpleCondition returns EditorConditionExpression:
 	{EditorForbid}
 	'forbid' pattern=[EditorPattern] |
 	{EditorConstraint}
-	'if' premise=[EditorPattern] 'then' conclusions+=[EditorPattern] ('||' conclusions+=[EditorPattern])*;
+	'if' premise=[EditorPattern] 'then'
+	'(' conclusions+=[EditorPattern] ('||' conclusions+=[EditorPattern])* ')';

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
@@ -111,11 +111,10 @@ EditorNegativeExpression returns EditorConditionExpression:
 
 EditorSimpleCondition returns EditorConditionExpression:
 	{EditorConditionReference}
-	'ref' condition=[EditorCondition] |
+	'check' condition=[EditorCondition] |
 	{EditorEnforce}
 	'enforce' pattern=[EditorPattern] |
 	{EditorForbid}
 	'forbid' pattern=[EditorPattern] |
 	{EditorConstraint}
-	'check' premise=[EditorPattern] 'implies' conclusions+=[EditorPattern] ('||'
-	conditions+=[EditorPattern])*;
+	'if' premise=[EditorPattern] 'then' conclusions+=[EditorPattern] ('||' conclusions+=[EditorPattern])*;

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
@@ -5,8 +5,8 @@ generate gT "http://www.emoflon.org/ibex/gt/editor/GT"
 
 EditorGTFile:
 	(imports+=EditorImport)*
-	(patterns+=EditorPattern)*
-	(conditions+=EditorCondition)*;
+	(patterns+=EditorPattern |
+	conditions+=EditorCondition)*;
 
 EditorImport:
 	'import' name=STRING;
@@ -97,18 +97,24 @@ EditorAnd returns EditorConditionExpression:
 	EditorNegation ({EditorAnd.left=current} '&&' right=EditorNegation)*;
 
 EditorNegation returns EditorConditionExpression:
-	'!' EditorBasicExpression |
-	EditorBasicExpression;
+	EditorBasicExpression |
+	EditorNegativeExpression;
 
 EditorBasicExpression returns EditorConditionExpression:
-	EditorPatternCondition |
+	EditorSimpleCondition |
 	'(' EditorOr ')';
 
-EditorPatternCondition returns EditorConditionExpression:
+EditorNegativeExpression returns EditorConditionExpression:
+	'!' (EditorSimpleCondition |
+	'(' EditorOr ')');
+
+EditorSimpleCondition returns EditorConditionExpression:
+	{EditorConditionReference}
+	'ref' condition=[EditorCondition] |
 	{EditorEnforce}
 	'enforce' pattern=[EditorPattern] |
 	{EditorForbid}
 	'forbid' pattern=[EditorPattern] |
 	{EditorConstraint}
-	'check' premise=[EditorPattern]
-	'implies' conclusions+=[EditorPattern] ('||' conditions+=[EditorPattern])*;
+	'check' premise=[EditorPattern] 'implies' conclusions+=[EditorPattern] ('||'
+	conditions+=[EditorPattern])*;

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/formatting2/GTFormatter.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/formatting2/GTFormatter.xtend
@@ -7,7 +7,7 @@ import org.eclipse.xtext.formatting2.AbstractFormatter2
 import org.eclipse.xtext.formatting2.IFormattableDocument
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 
-import org.emoflon.ibex.gt.editor.gT.EditorAnd
+import org.emoflon.ibex.gt.editor.gT.EditorAndCondition
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorCondition
 import org.emoflon.ibex.gt.editor.gT.EditorConditionExpression
@@ -19,7 +19,7 @@ import org.emoflon.ibex.gt.editor.gT.EditorGTFile
 import org.emoflon.ibex.gt.editor.gT.EditorImport
 import org.emoflon.ibex.gt.editor.gT.EditorNode
 import org.emoflon.ibex.gt.editor.gT.EditorOperator
-import org.emoflon.ibex.gt.editor.gT.EditorOr
+import org.emoflon.ibex.gt.editor.gT.EditorOrCondition
 import org.emoflon.ibex.gt.editor.gT.EditorParameter
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
 import org.emoflon.ibex.gt.editor.gT.EditorReference
@@ -182,15 +182,15 @@ class GTFormatter extends AbstractFormatter2 {
 		condition.regionFor.keyword('=').surround[oneSpace]
 
 		// Format condition value.
-		condition.condition.format
+		condition.expression.format
 	}
 
-	def dispatch void format(EditorOr condition, extension IFormattableDocument document) {
+	def dispatch void format(EditorOrCondition condition, extension IFormattableDocument document) {
 		condition.regionFor.keyword('||').surround[oneSpace]
 		formatExpressions(condition.left, condition.right, document)
 	}
 
-	def dispatch void format(EditorAnd condition, extension IFormattableDocument document) {
+	def dispatch void format(EditorAndCondition condition, extension IFormattableDocument document) {
 		condition.regionFor.keyword('&&').surround[oneSpace]
 		formatExpressions(condition.left, condition.right, document)
 	}

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
@@ -30,9 +30,6 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 	public static val REFERENCE_TARGET_NODE_NOT_FOUND = CODE_PREFIX + "reference.target.nodeNotFound"
 	public static val REFERENCE_TARGET_NODE_NOT_FOUND_MESSAGE = "Could not find node '%s' of type '%s'."
 
-	public static val RULE_SUPER_RULE_NOT_FOUND = CODE_PREFIX + "rule.superRules.notFound"
-	public static val RULE_SUPER_RULE_NOT_FOUND_MESSAGE = "Could not find rule '%s'."
-
 	override getUnresolvedProxyMessage(ILinkingDiagnosticContext context) {
 		var linkText = "";
 		try {
@@ -85,15 +82,6 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 				String.format(REFERENCE_TARGET_NODE_NOT_FOUND_MESSAGE, linkText, expectedType),
 				Severity.ERROR,
 				REFERENCE_TARGET_NODE_NOT_FOUND
-			)
-		}
-
-		// Super rule not found in scope.
-		if (context.reference === GTPackage.Literals.EDITOR_PATTERN__SUPER_PATTERNS) {
-			return new DiagnosticMessage(
-				String.format(RULE_SUPER_RULE_NOT_FOUND_MESSAGE, linkText),
-				Severity.ERROR,
-				RULE_SUPER_RULE_NOT_FOUND
 			)
 		}
 

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTScopeProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTScopeProvider.xtend
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.gt.editor.scoping
 
-import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EEnum
 import org.eclipse.emf.ecore.EObject

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/utils/GTEditorPatternUtils.java
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/utils/GTEditorPatternUtils.java
@@ -26,8 +26,13 @@ public class GTEditorPatternUtils {
 	 */
 	public static Set<EditorPattern> getAllSuperPatterns(final EditorPattern pattern) {
 		Set<EditorPattern> patterns = new HashSet<EditorPattern>();
-		patterns.addAll(pattern.getSuperPatterns());
-		pattern.getSuperPatterns().forEach(p -> patterns.addAll(getAllSuperPatterns(p)));
+		for (EditorPattern superPattern : pattern.getSuperPatterns()) {
+			// Check necessary to avoid 
+			if (!isRefinementOf(superPattern, pattern)) {
+				patterns.add(superPattern);
+				patterns.addAll(getAllSuperPatterns(superPattern));
+			}
+		}
 		return patterns;
 	}
 

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
@@ -245,8 +245,8 @@ class GTValidator extends AbstractGTValidator {
 			}
 		}
 
-		// The pattern must contain at least one constraint or refine multiple patterns.
-		if (pattern.nodes.size == 0 && pattern.superPatterns.size < 2) {
+		// The pattern must contain at least one node or refine multiple patterns or have graph conditions.
+		if (pattern.nodes.size == 0 && pattern.superPatterns.size < 2 && pattern.conditions.size == 0) {
 			error(
 				String.format(RULE_EMPTY_MESSAGE, pattern.name),
 				GTPackage.Literals.EDITOR_PATTERN__NODES,

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
@@ -4,6 +4,7 @@ import java.util.Collection
 
 import org.eclipse.emf.ecore.EPackage
 import org.eclipse.xtext.validation.Check
+import org.eclipse.xtext.validation.CheckType
 
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorGTFile
@@ -265,6 +266,22 @@ class GTValidator extends AbstractGTValidator {
 			)
 		}
 
+		// The super patterns of the pattern must be distinct.
+		if (pattern.superPatterns.size !== pattern.superPatterns.stream.distinct.count) {
+			error(
+				String.format(RULE_SUPER_RULES_DUPLICATE_MESSAGE, pattern.name),
+				GTPackage.Literals.EDITOR_PATTERN__SUPER_PATTERNS,
+				RULE_SUPER_RULES_DUPLICATE,
+				pattern.name
+			)
+		}
+	}
+
+	@Check(CheckType.NORMAL) // Only on save/build.
+	def checkPatternTypeAndRefinement(EditorPattern pattern) {
+		println("checkPatternTypeAndRefinement " + pattern)
+
+		// Type: pattern vs. rule
 		val flattenedPattern = new GTFlattener(pattern).flattenedPattern
 		val isRule = GTEditorPatternUtils.containsCreatedOrDeletedElements(flattenedPattern)
 		if (isRule && pattern.type === EditorPatternType.PATTERN) {
@@ -286,16 +303,6 @@ class GTValidator extends AbstractGTValidator {
 
 		if (pattern.superPatterns.isEmpty) {
 			return;
-		}
-
-		// The super patterns of the pattern must be distinct.
-		if (pattern.superPatterns.size !== pattern.superPatterns.stream.distinct.count) {
-			error(
-				String.format(RULE_SUPER_RULES_DUPLICATE_MESSAGE, pattern.name),
-				GTPackage.Literals.EDITOR_PATTERN__SUPER_PATTERNS,
-				RULE_SUPER_RULES_DUPLICATE,
-				pattern.name
-			)
 		}
 
 		// Parameter names must be equal to definitions in the super pattern.

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
@@ -177,10 +177,10 @@ class GTValidator extends AbstractGTValidator {
 	public static val REFERENCE_TARGET_EXPECT_CONTEXT_OR_DELETE_MESSAGE = "The target of the deleted reference '%s must be a context or a deleted node."
 
 	// Errors for conditions
-	public static val CONDITION_PATTERN_INVALID_PARAMETERS = CODE_PREFIX + "condition.pattern.invalid"
+	public static val CONDITION_PATTERN_INVALID_PARAMETERS = CODE_PREFIX + "condition.pattern.invalid.hasParameters"
 	public static val CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE = "Condition may not use '%s' because it has parameters."
 
-	public static val CONDITION_PATTERN_INVALID_RULE = CODE_PREFIX + "condition.pattern.invalid"
+	public static val CONDITION_PATTERN_INVALID_RULE = CODE_PREFIX + "condition.pattern.invalid.isRule"
 	public static val CONDITION_PATTERN_INVALID_RULE_MESSAGE = "Condition may not use '%s' because it is a rule."
 
 	@Check


### PR DESCRIPTION
Graph conditions
- Add conditions `enforce <pattern>`, `forbid <pattern>` and `if <pattern> then (<pattern> || ... || <pattern>)` (those patterns must not have any parameters)
- Add logical expressions using `&&`, `||`, `!`, `check <other-condition>` as conditions
- JUnit tests for the validation of conditions

Rule refinement
- Allow rules from other files in the refinement hierarchy

Bugfixes: #76, #80 