### PR TITLE
GT editor: bugfixes, DNF for graph conditons

### DIFF
--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTFormattingTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTFormattingTest.xtend
@@ -229,6 +229,7 @@ class GTFormattingTest {
 			pattern findClassWithoutAnnotation {
 				clazz: EClass
 			}
+			when noAnnotation || hasAnnotation
 			
 			abstract pattern findClassWithAnnotation {
 				clazz: EClass {
@@ -242,18 +243,16 @@ class GTFormattingTest {
 			
 			condition hasAnnotation = enforce findClassifierWithAnnotation
 			
-			condition orTest = check noAnnotation || check hasAnnotation
-			
 			condition andTest = check noAnnotation && check hasAnnotation
-			
-			condition hasAnnotationConstraint = if findClassWithoutAnnotation then (findClassWithoutAnnotation || findClassWithAnnotation)
 		'''
 		testFormatting(
 			expected,
 			'''
 				import "http://www.eclipse.org/emf/2002/Ecore"	
-					pattern findClassWithoutAnnotation {clazz: EClass}
-					
+					pattern findClassWithoutAnnotation {clazz: EClass}	when 
+					noAnnotation 
+					|| 
+					hasAnnotation
 					
 				abstract pattern findClassWithAnnotation {
 				clazz: EClass {-eAnnotations -> annotation}
@@ -263,17 +262,8 @@ class GTFormattingTest {
 					= forbid  findClassWithAnnotation
 				condition hasAnnotation  =  enforce  findClassifierWithAnnotation
 				
-				condition  orTest 
-					= check   noAnnotation
-						|| check  hasAnnotation
-							
 					condition  andTest 
 					= check noAnnotation    &&    	check hasAnnotation
-				
-					condition hasAnnotationConstraint  =  if findClassWithoutAnnotation 
-					then (findClassWithoutAnnotation  ||  findClassWithAnnotation)
-				
-				
 			'''
 		)
 	}

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
@@ -27,23 +27,10 @@ class GTParsingConditionsTest extends GTParsingTest {
 				++ object: EObject
 			}
 			
-			condition constraintCond = if a then (a || b) 
 			condition enforceCond = enforce a
 			condition forbidCond = forbid a
 		''')
 		assertFile(file, 2)
-		assertValidationErrors(
-			file,
-			GTPackage.eINSTANCE.editorConstraint,
-			GTValidator.CONDITION_PATTERN_INVALID_RULE,
-			String.format(GTValidator.CONDITION_PATTERN_INVALID_RULE_MESSAGE, 'a')
-		)
-		assertValidationErrors(
-			file,
-			GTPackage.eINSTANCE.editorConstraint,
-			GTValidator.CONDITION_PATTERN_INVALID_RULE,
-			String.format(GTValidator.CONDITION_PATTERN_INVALID_RULE_MESSAGE, 'b')
-		)
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorEnforce,
@@ -71,23 +58,10 @@ class GTParsingConditionsTest extends GTParsingTest {
 				object: EObject
 			}
 			
-			condition constraintCond = if a then (a || b) 
 			condition enforceCond = enforce a
 			condition forbidCond = forbid a
 		''')
 		assertFile(file, 2)
-		assertValidationErrors(
-			file,
-			GTPackage.eINSTANCE.editorConstraint,
-			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
-			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'a')
-		)
-		assertValidationErrors(
-			file,
-			GTPackage.eINSTANCE.editorConstraint,
-			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
-			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'b')
-		)
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorEnforce,

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
@@ -15,6 +15,52 @@ import org.junit.runner.RunWith
 class GTParsingConditionsTest extends GTParsingTest {
 
 	@Test
+	def void errorIfMultipleConditionsWithTheSameName() {
+		val file = parse('''
+			import "«ecoreImport»"
+			
+			pattern a {
+				object: EObject
+			}
+			
+			condition b = enforce a
+			condition b = forbid a
+		''')
+		assertFile(file)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorCondition,
+			GTValidator.NAME_EXPECT_UNIQUE,
+			String.format(GTValidator.CONDITION_NAME_MULTIPLE_DECLARATIONS_MESSAGE, 'b', 'twice')
+		)
+	}
+
+	@Test
+	def void errorIfNoDistinctConditionsForPattern() {
+		val file = parse('''
+			import "«ecoreImport»"
+			
+			pattern a {
+				anyObject: EObject
+			}
+			
+			pattern b {
+				object: EObject
+			}
+			when c || c
+			
+			condition c = forbid a
+		''')
+		assertFile(file, 2)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorPattern,
+			GTValidator.PATTERN_CONDITIONS_DUPLICATE,
+			String.format(GTValidator.PATTERN_CONDITIONS_DUPLICATE_MESSAGE, 'b')
+		)
+	}
+
+	@Test
 	def void errorIfConditionReferencesRule() {
 		val file = parse('''
 			import "«ecoreImport»"

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingConditionsTest.xtend
@@ -69,14 +69,11 @@ class GTParsingConditionsTest extends GTParsingTest {
 				++ object: EObject
 			}
 			
-			rule b {
-				++ object: EObject
-			}
-			
 			condition enforceCond = enforce a
+			
 			condition forbidCond = forbid a
 		''')
-		assertFile(file, 2)
+		assertFile(file)
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorEnforce,
@@ -100,14 +97,11 @@ class GTParsingConditionsTest extends GTParsingTest {
 				object: EObject
 			}
 			
-			pattern b(i: EInt) {
-				object: EObject
-			}
-			
 			condition enforceCond = enforce a
+			
 			condition forbidCond = forbid a
 		''')
-		assertFile(file, 2)
+		assertFile(file)
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorEnforce,
@@ -119,6 +113,35 @@ class GTParsingConditionsTest extends GTParsingTest {
 			GTPackage.eINSTANCE.editorForbid,
 			GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS,
 			String.format(GTValidator.CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, 'a')
+		)
+	}
+
+	@Test
+	def void errorIfConditionReferencesPatternWithMultipleConditions() {
+		val file = parse('''
+			import "«ecoreImport»"
+			
+			pattern p1 {
+				object: EObject
+			}
+			
+			condition c1 = enforce p1
+			
+			condition c2 = enforce p1
+			
+			pattern p2 {
+				object: EObject
+			}
+			when c1 || c2
+			
+			condition c3 = enforce p2
+		''')
+		assertFile(file, 2)
+		assertValidationErrors(
+			file,
+			GTPackage.eINSTANCE.editorEnforce,
+			GTValidator.CONDITION_PATTERN_INVALID_CONDITIONS,
+			String.format(GTValidator.CONDITION_PATTERN_INVALID_CONDITIONS_MESSAGE, 'p2')
 		)
 	}
 }

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingPatternRefinementTest.xtend
@@ -147,8 +147,8 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER,
-			String.format(GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER_MESSAGE, 'r', 'name',
+			GTValidator.PATTERN_SUPER_PATTERNS_INVALID_PARAMETER,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_INVALID_PARAMETER_MESSAGE, 'r', 'name',
 				GTValidator.concatNames(#['EBoolean', 'EString']))
 		)
 	}
@@ -171,8 +171,8 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER,
-			String.format(GTValidator.PATTERN_REFINEMENT_INVALID_PARAMETER_MESSAGE, 'r', 'name',
+			GTValidator.PATTERN_SUPER_PATTERNS_INVALID_PARAMETER,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_INVALID_PARAMETER_MESSAGE, 'r', 'name',
 				GTValidator.concatNames(#['EBoolean', 'EString']))
 		)
 	}
@@ -201,8 +201,9 @@ class GTParsingPatternRefinementTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorPattern,
-			GTValidator.PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT,
-			String.format(GTValidator.PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE, 'renameClass', 'clazz')
+			GTValidator.PATTERN_SUPER_PATTERNS_INVALID_ATTRIBUTE_ASSIGNMENT,
+			String.format(GTValidator.PATTERN_SUPER_PATTERNS_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE, 'renameClass',
+				'clazz')
 		)
 	}
 

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
@@ -229,7 +229,7 @@ class GTPlantUMLGenerator {
 	 * Prints the conditions of the pattern.
 	 */
 	private static def String getConditionString(EditorPattern pattern) {
-		'''«FOR c : pattern.conditions SEPARATOR ' **||** '»«getConditionString(c.expression)»«ENDFOR»'''
+		'''«FOR c : pattern.conditions SEPARATOR ' **||** '»(«getConditionString(c.expression)»)«ENDFOR»'''
 	}
 
 	/**
@@ -237,7 +237,7 @@ class GTPlantUMLGenerator {
 	 */
 	private static def String getConditionString(EditorConditionExpression condition) {
 		if (condition instanceof EditorAndCondition) {
-			return '''(«getConditionString(condition.left)» **&&** «getConditionString(condition.right)»)'''
+			return '''«getConditionString(condition.left)» **&&** «getConditionString(condition.right)»'''
 		}
 		if (condition instanceof EditorConditionReference) {
 			return '''«getConditionString(condition.condition.expression)»'''

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
@@ -60,26 +60,22 @@ class GTPlantUMLGenerator {
 				FontColor White
 			}
 			
-			«IF pattern.conditions.isEmpty»
+			namespace «pattern.name» {
 				«visualizeGraph(flattenedPattern)»
-			«ELSE»
-				namespace «pattern.name» {
-					«visualizeGraph(flattenedPattern)»
+			}
+			
+			«FOR p : getConditionPatterns(pattern)»
+				«val f = new GTFlattener(p).getFlattenedPattern»
+				namespace «p.name» #EEEEEE {
+					«visualizeGraph(f)»
 				}
 				
-				«FOR p : getConditionPatterns(pattern)»
-					«val f = new GTFlattener(p).getFlattenedPattern»
-					namespace «p.name» #EEEEEE {
-						«visualizeGraph(f)»
-					}
-					
-					«FOR node : f.nodes»
-						«IF nodeNamesInFlattenedPattern.contains(node.name)»
-							"«pattern.name».«nodeName(node)»" #--# "«p.name».«nodeName(node)»"
-						«ENDIF»
-					«ENDFOR»
+				«FOR node : f.nodes»
+					«IF nodeNamesInFlattenedPattern.contains(node.name)»
+						"«pattern.name».«nodeName(node)»" #--# "«p.name».«nodeName(node)»"
+					«ENDIF»
 				«ENDFOR»
-			«ENDIF»
+			«ENDFOR»
 			
 			«IF !pattern.conditions.isEmpty»
 				legend bottom

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
@@ -229,7 +229,11 @@ class GTPlantUMLGenerator {
 	 * Prints the conditions of the pattern.
 	 */
 	private static def String getConditionString(EditorPattern pattern) {
-		'''«FOR c : pattern.conditions SEPARATOR ' **||** '»(«getConditionString(c.expression)»)«ENDFOR»'''
+		'''
+			«FOR c : pattern.conditions SEPARATOR ' **||** '»
+				(«getConditionString(c.expression)»)
+			«ENDFOR»
+		'''
 	}
 
 	/**

--- a/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
+++ b/org.emoflon.ibex.gt.editor.ui/src/org/emoflon/ibex/gt/editor/ui/visualization/GTPlantUMLGenerator.xtend
@@ -9,16 +9,13 @@ import org.emoflon.ibex.gt.editor.gT.EditorConditionReference
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorAttributeExpression
 import org.emoflon.ibex.gt.editor.gT.EditorConditionExpression
-import org.emoflon.ibex.gt.editor.gT.EditorConstraint
 import org.emoflon.ibex.gt.editor.gT.EditorEnforce
 import org.emoflon.ibex.gt.editor.gT.EditorEnumExpression
 import org.emoflon.ibex.gt.editor.gT.EditorExpression
 import org.emoflon.ibex.gt.editor.gT.EditorForbid
 import org.emoflon.ibex.gt.editor.gT.EditorLiteralExpression
-import org.emoflon.ibex.gt.editor.gT.EditorNegativeCondition
 import org.emoflon.ibex.gt.editor.gT.EditorNode
 import org.emoflon.ibex.gt.editor.gT.EditorOperator
-import org.emoflon.ibex.gt.editor.gT.EditorOrCondition
 import org.emoflon.ibex.gt.editor.gT.EditorParameter
 import org.emoflon.ibex.gt.editor.gT.EditorParameterExpression
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
@@ -212,25 +209,12 @@ class GTPlantUMLGenerator {
 	 */
 	private static def Set<EditorPattern> getConditionPatterns(EditorConditionExpression condition) {
 		val patterns = new HashSet
-
 		if (condition instanceof EditorAndCondition) {
 			patterns.addAll(getConditionPatterns(condition.left))
 			patterns.addAll(getConditionPatterns(condition.right))
 		}
-		if (condition instanceof EditorOrCondition) {
-			patterns.addAll(getConditionPatterns(condition.left))
-			patterns.addAll(getConditionPatterns(condition.right))
-		}
-		if (condition instanceof EditorNegativeCondition) {
-			patterns.addAll(getConditionPatterns(condition.expression))
-		}
-
 		if (condition instanceof EditorConditionReference) {
 			patterns.addAll(getConditionPatterns(condition.condition.expression))
-		}
-		if (condition instanceof EditorConstraint) {
-			patterns.add(condition.premise)
-			patterns.addAll(condition.conclusions)
 		}
 		if (condition instanceof EditorEnforce) {
 			patterns.add(condition.pattern)
@@ -245,7 +229,7 @@ class GTPlantUMLGenerator {
 	 * Prints the conditions of the pattern.
 	 */
 	private static def String getConditionString(EditorPattern pattern) {
-		'''«FOR c : pattern.conditions SEPARATOR ' **&&** '»«getConditionString(c.expression)»«ENDFOR»'''
+		'''«FOR c : pattern.conditions SEPARATOR ' **||** '»«getConditionString(c.expression)»«ENDFOR»'''
 	}
 
 	/**
@@ -255,18 +239,8 @@ class GTPlantUMLGenerator {
 		if (condition instanceof EditorAndCondition) {
 			return '''(«getConditionString(condition.left)» **&&** «getConditionString(condition.right)»)'''
 		}
-		if (condition instanceof EditorOrCondition) {
-			return '''(«getConditionString(condition.left)» **||** «getConditionString(condition.right)»)'''
-		}
-		if (condition instanceof EditorNegativeCondition) {
-			return '''**!**«getConditionString(condition.expression)»'''
-		}
-
 		if (condition instanceof EditorConditionReference) {
 			return '''«getConditionString(condition.condition.expression)»'''
-		}
-		if (condition instanceof EditorConstraint) {
-			return '''**if** «condition.premise.name» **then** «FOR c : condition.conclusions»«c.name»«ENDFOR»'''
 		}
 		if (condition instanceof EditorEnforce) {
 			return '''**enforce** «condition.pattern.name»'''

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/GT.xtext
@@ -20,7 +20,7 @@ EditorPattern:
 	('{'
 	(nodes+=EditorNode)*
 	'}')?
-	('when' conditions+=[EditorCondition] ('&&' conditions+=[EditorCondition])*)?;
+	('when' conditions+=[EditorCondition] ('||' conditions+=[EditorCondition])*)?;
 
 enum EditorPatternType:
 	PATTERN='pattern' |
@@ -89,26 +89,16 @@ EditorCondition:
 	'=' expression=EditorConditionExpression;
 
 EditorConditionExpression:
-	EditorOrCondition;
-
-EditorOrCondition returns EditorConditionExpression:
-	EditorAndCondition ({EditorOrCondition.left=current} '||' right=EditorAndCondition)*;
+	EditorAndCondition;
 
 EditorAndCondition returns EditorConditionExpression:
-	EditorNegation ({EditorAndCondition.left=current} '&&' right=EditorNegation)*;
-
-EditorNegation returns EditorConditionExpression:
-	{EditorNegativeCondition} '!' expression=EditorSimpleCondition |
-	EditorSimpleCondition;
+	EditorSimpleCondition ({EditorAndCondition.left=current} '&&' right=EditorSimpleCondition)*;
 
 EditorSimpleCondition returns EditorConditionExpression:
-	'(' EditorOrCondition ')' |
+	'(' EditorAndCondition ')' |
 	{EditorConditionReference}
 	'check' condition=[EditorCondition] |
 	{EditorEnforce}
 	'enforce' pattern=[EditorPattern] |
 	{EditorForbid}
-	'forbid' pattern=[EditorPattern] |
-	{EditorConstraint}
-	'if' premise=[EditorPattern] 'then'
-	'(' conclusions+=[EditorPattern] ('||' conclusions+=[EditorPattern])* ')';
+	'forbid' pattern=[EditorPattern];

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/formatting2/GTFormatter.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/formatting2/GTFormatter.xtend
@@ -10,16 +10,13 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.emoflon.ibex.gt.editor.gT.EditorAndCondition
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorCondition
-import org.emoflon.ibex.gt.editor.gT.EditorConditionExpression
 import org.emoflon.ibex.gt.editor.gT.EditorConditionReference
-import org.emoflon.ibex.gt.editor.gT.EditorConstraint
 import org.emoflon.ibex.gt.editor.gT.EditorEnforce
 import org.emoflon.ibex.gt.editor.gT.EditorForbid
 import org.emoflon.ibex.gt.editor.gT.EditorGTFile
 import org.emoflon.ibex.gt.editor.gT.EditorImport
 import org.emoflon.ibex.gt.editor.gT.EditorNode
 import org.emoflon.ibex.gt.editor.gT.EditorOperator
-import org.emoflon.ibex.gt.editor.gT.EditorOrCondition
 import org.emoflon.ibex.gt.editor.gT.EditorParameter
 import org.emoflon.ibex.gt.editor.gT.EditorPattern
 import org.emoflon.ibex.gt.editor.gT.EditorReference
@@ -113,6 +110,15 @@ class GTFormatter extends AbstractFormatter2 {
 
 		// Empty line between nodes.
 		formatList(pattern.nodes, document, 1, 2, 1)
+
+		// New line before and one space after for keyword "when".
+		pattern.regionFor.keyword("when").prepend[newLine]
+		pattern.regionFor.keyword("when").append[oneSpace]
+
+		// One space before and after "||".
+		pattern.regionFor.keywords('||').forEach [
+			it.surround[oneSpace]
+		]
 	}
 
 	def dispatch void format(EditorParameter parameter, extension IFormattableDocument document) {
@@ -185,14 +191,10 @@ class GTFormatter extends AbstractFormatter2 {
 		condition.expression.format
 	}
 
-	def dispatch void format(EditorOrCondition condition, extension IFormattableDocument document) {
-		condition.regionFor.keyword('||').surround[oneSpace]
-		formatExpressions(condition.left, condition.right, document)
-	}
-
 	def dispatch void format(EditorAndCondition condition, extension IFormattableDocument document) {
 		condition.regionFor.keyword('&&').surround[oneSpace]
-		formatExpressions(condition.left, condition.right, document)
+		condition.left.format
+		condition.right.format
 	}
 
 	def dispatch void format(EditorConditionReference condition, extension IFormattableDocument document) {
@@ -205,23 +207,6 @@ class GTFormatter extends AbstractFormatter2 {
 
 	def dispatch void format(EditorForbid condition, extension IFormattableDocument document) {
 		condition.regionFor.keyword('forbid').append[oneSpace]
-	}
-
-	def dispatch void format(EditorConstraint condition, extension IFormattableDocument document) {
-		condition.regionFor.keyword('if').append[oneSpace]
-		condition.regionFor.keyword('then').surround[oneSpace]
-		condition.regionFor.keywords('||').forEach [
-			it.surround[oneSpace]
-		]
-	}
-
-	/**
-	 * Formats the given condition expressions.
-	 */
-	private static def formatExpressions(EditorConditionExpression left, EditorConditionExpression right,
-		extension IFormattableDocument document) {
-		left.format
-		right.format
 	}
 
 	/**

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTScopeProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTScopeProvider.xtend
@@ -9,7 +9,6 @@ import org.eclipse.xtext.scoping.impl.FilteringScope
 
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 import org.emoflon.ibex.gt.editor.gT.EditorAttributeExpression
-import org.emoflon.ibex.gt.editor.gT.EditorConstraint
 import org.emoflon.ibex.gt.editor.gT.EditorEnforce
 import org.emoflon.ibex.gt.editor.gT.EditorEnumExpression
 import org.emoflon.ibex.gt.editor.gT.EditorForbid
@@ -104,10 +103,7 @@ class GTScopeProvider extends AbstractGTScopeProvider {
 
 	def isPatternOfGraphCondition(EObject context, EReference reference) {
 		return (context instanceof EditorEnforce && reference == GTPackage.Literals.EDITOR_ENFORCE__PATTERN) ||
-			(context instanceof EditorForbid && reference == GTPackage.Literals.EDITOR_FORBID__PATTERN) ||
-			(context instanceof EditorConstraint &&
-				(reference == GTPackage.Literals.EDITOR_CONSTRAINT__PREMISE || reference == GTPackage.Literals.EDITOR_CONSTRAINT__CONCLUSIONS)
-			)
+			(context instanceof EditorForbid && reference == GTPackage.Literals.EDITOR_FORBID__PATTERN)
 	}
 
 	def isNodeType(EObject context, EReference reference) {

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/utils/GTFlattener.java
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/utils/GTFlattener.java
@@ -72,6 +72,7 @@ public class GTFlattener {
 		flattenedPattern.setName(pattern.getName());
 		flattenedPattern.getParameters().addAll(parameters);
 		flattenedPattern.getNodes().addAll(nodes);
+		flattenedPattern.getConditions().addAll(pattern.getConditions());
 	}
 
 	/**

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
@@ -103,12 +103,12 @@ class GTValidator extends AbstractGTValidator {
 	public static val PATTERN_SUPER_PATTERNS_INVALID = CODE_PREFIX + "pattern.superPatterns.invalid"
 	public static val PATTERN_SUPER_PATTERNS_INVALID_MESSAGE = "Cycle in refinement hierarchy: '%s' and '%s'."
 
-	public static val PATTERN_REFINEMENT_INVALID_PARAMETER = CODE_PREFIX + "pattern.superPatterns.invalidParameter"
-	public static val PATTERN_REFINEMENT_INVALID_PARAMETER_MESSAGE = "Pattern/rule '%s' has conflicting type declarations for parameter '%s': %s."
+	public static val PATTERN_SUPER_PATTERNS_INVALID_PARAMETER = CODE_PREFIX + "pattern.superPatterns.invalidParameter"
+	public static val PATTERN_SUPER_PATTERNS_INVALID_PARAMETER_MESSAGE = "Pattern/rule '%s' has conflicting type declarations for parameter '%s': %s."
 
-	public static val PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT = CODE_PREFIX +
+	public static val PATTERN_SUPER_PATTERNS_INVALID_ATTRIBUTE_ASSIGNMENT = CODE_PREFIX +
 		"pattern.superPatterns.invalidAttributeAssignment"
-	public static val PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE = "Rule '%s' has conflicting attribute assignments for node '%s'."
+	public static val PATTERN_SUPER_PATTERNS_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE = "Rule '%s' has conflicting attribute assignments for node '%s'."
 
 	// Errors for parameters.
 	public static val PARAMETER_NAME_CONTAINS_UNDERSCORES_MESSAGE = "Parameter name '%s' contains underscores. Use camelCase instead."
@@ -343,9 +343,10 @@ class GTValidator extends AbstractGTValidator {
 			if (allTypesForName.size > 1) {
 				val typeList = concatNames(allTypesForName.map[it.name].toSet)
 				error(
-					String.format(PATTERN_REFINEMENT_INVALID_PARAMETER_MESSAGE, pattern.name, parameterName, typeList),
+					String.format(PATTERN_SUPER_PATTERNS_INVALID_PARAMETER_MESSAGE, pattern.name, parameterName,
+						typeList),
 					GTPackage.Literals.EDITOR_PATTERN__SUPER_PATTERNS,
-					PATTERN_REFINEMENT_INVALID_PARAMETER
+					PATTERN_SUPER_PATTERNS_INVALID_PARAMETER
 				)
 			}
 		}
@@ -355,9 +356,9 @@ class GTValidator extends AbstractGTValidator {
 		for (nodeName : allNodes.map[it.name].toSet) {
 			if (GTFlatteningUtils.hasConflictingAssignment(allNodes, nodeName)) {
 				error(
-					String.format(PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE, pattern.name, nodeName),
+					String.format(PATTERN_SUPER_PATTERNS_INVALID_ATTRIBUTE_ASSIGNMENT_MESSAGE, pattern.name, nodeName),
 					GTPackage.Literals.EDITOR_PATTERN__SUPER_PATTERNS,
-					PATTERN_REFINEMENT_INVALID_ATTRIBUTE_ASSIGNMENT
+					PATTERN_SUPER_PATTERNS_INVALID_ATTRIBUTE_ASSIGNMENT
 				)
 			}
 		}

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
@@ -182,6 +182,10 @@ class GTValidator extends AbstractGTValidator {
 	// Errors for conditions
 	public static val CONDITION_NAME_MULTIPLE_DECLARATIONS_MESSAGE = "Condition '%s' must not be declared %s."
 
+	public static val CONDITION_PATTERN_INVALID_CONDITIONS = CODE_PREFIX +
+		"condition.pattern.invalid.hasMultipleConditions"
+	public static val CONDITION_PATTERN_INVALID_CONDITIONS_MESSAGE = "Condition may not use '%s' because it has multiple conditions."
+
 	public static val CONDITION_PATTERN_INVALID_PARAMETERS = CODE_PREFIX + "condition.pattern.invalid.hasParameters"
 	public static val CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE = "Condition may not use '%s' because it has parameters."
 
@@ -725,6 +729,7 @@ class GTValidator extends AbstractGTValidator {
 	 * Validates that the given pattern has no parameters and is no rule. 
 	 */
 	def checkPatternInCondition(EditorPattern pattern, EStructuralFeature feature) {
+		// Patterns in conditions must not be rules.
 		if (pattern.type === EditorPatternType.RULE) {
 			error(
 				String.format(CONDITION_PATTERN_INVALID_RULE_MESSAGE, pattern.name),
@@ -732,12 +737,22 @@ class GTValidator extends AbstractGTValidator {
 				CONDITION_PATTERN_INVALID_RULE
 			)
 		} else {
+			// Patterns in conditions must not have any parameters.
 			if (pattern.parameters.size > 0) {
 				error(
 					String.format(CONDITION_PATTERN_INVALID_PARAMETERS_MESSAGE, pattern.name),
 					feature,
 					CONDITION_PATTERN_INVALID_PARAMETERS
 				)
+			} else {
+				// Patterns in conditons must not have more than one condition.
+				if (pattern.conditions.size > 1) {
+					error(
+						String.format(CONDITION_PATTERN_INVALID_CONDITIONS_MESSAGE, pattern.name),
+						feature,
+						CONDITION_PATTERN_INVALID_CONDITIONS
+					)
+				}
 			}
 		}
 	}

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/validation/GTValidator.xtend
@@ -8,7 +8,6 @@ import org.eclipse.xtext.validation.Check
 import org.eclipse.xtext.validation.CheckType
 
 import org.emoflon.ibex.gt.editor.gT.EditorAttribute
-import org.emoflon.ibex.gt.editor.gT.EditorConstraint
 import org.emoflon.ibex.gt.editor.gT.EditorEnforce
 import org.emoflon.ibex.gt.editor.gT.EditorForbid
 import org.emoflon.ibex.gt.editor.gT.EditorGTFile
@@ -680,14 +679,6 @@ class GTValidator extends AbstractGTValidator {
 	@Check
 	def checkForbid(EditorForbid forbid) {
 		checkPatternInCondition(forbid.pattern, GTPackage.Literals.EDITOR_FORBID__PATTERN)
-	}
-
-	@Check
-	def checkConstraint(EditorConstraint constraint) {
-		checkPatternInCondition(constraint.premise, GTPackage.Literals.EDITOR_CONSTRAINT__PREMISE)
-		constraint.conclusions.forEach [
-			checkPatternInCondition(it, GTPackage.Literals.EDITOR_CONSTRAINT__CONCLUSIONS)
-		]
 	}
 
 	/**


### PR DESCRIPTION
- Changes the editor model such that conditions must be specified in DNF, i. e. a set containing simple clauses with positive/negative application conditons combined via AND
- Add JUnit tests for new scoping/validation rules (99 tests with covering 96,2 % of the scoping + validation code)