### PR TITLE
GT editor: improvements

### DIFF
--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
@@ -340,8 +340,8 @@ class GTParsingAttributesTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorAttribute,
-			Diagnostic::LINKING_DIAGNOSTIC,
-			"Couldn't resolve reference to EAttribute 'name'."
+			GTLinkingDiagnosticMessageProvider.ATTRIBUTE_NOT_FOUND,
+			String.format(GTLinkingDiagnosticMessageProvider.ATTRIBUTE_NOT_FOUND_MESSAGE, 'name')
 		)
 	}
 }

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingAttributesTest.xtend
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.gt.editor.tests
 
-import org.eclipse.xtext.diagnostics.Diagnostic
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.EditorRelation
@@ -102,7 +101,7 @@ class GTParsingAttributesTest extends GTParsingTest {
 				dataType: EDataType
 				
 				clazz: EClass {
-					.name == dataType.serializable
+					.name == dataType.x
 				}
 			}
 		''')
@@ -110,8 +109,8 @@ class GTParsingAttributesTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorAttributeExpression,
-			Diagnostic::LINKING_DIAGNOSTIC,
-			"Couldn't resolve reference to EAttribute 'serializable'."
+			GTLinkingDiagnosticMessageProvider.ATTRIBUTE_EXPRESSION_ATTRIBUTE_NOT_FOUND,
+			String.format(GTLinkingDiagnosticMessageProvider.ATTRIBUTE_EXPRESSION_ATTRIBUTE_NOT_FOUND_MESSAGE, 'x')
 		)
 	}
 

--- a/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingReferencesTest.xtend
+++ b/org.emoflon.ibex.gt.editor.tests/src/org/emoflon/ibex/gt/editor/tests/GTParsingReferencesTest.xtend
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.gt.editor.tests
 
-import org.eclipse.xtext.diagnostics.Diagnostic
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.emoflon.ibex.gt.editor.gT.EditorGTFile
@@ -8,7 +7,6 @@ import org.emoflon.ibex.gt.editor.gT.EditorOperator
 import org.emoflon.ibex.gt.editor.gT.GTPackage
 import org.emoflon.ibex.gt.editor.scoping.GTLinkingDiagnosticMessageProvider
 import org.emoflon.ibex.gt.editor.validation.GTValidator
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -82,7 +80,7 @@ class GTParsingReferencesTest extends GTParsingTest {
 		assertReference(ruleR.getNode(0).getReference(1), EditorOperator.DELETE, "eClassifiers", ruleS.getNode(1))
 	}
 
-	@Ignore("Needs Causes Exception, seems to be a scoping problem")
+//	@Ignore("Needs Causes Exception, seems to be a scoping problem")
 	@Test
 	def void errorIfNoSuchReferenceTypeInMetaModel() {
 		val file = parse('''
@@ -100,8 +98,8 @@ class GTParsingReferencesTest extends GTParsingTest {
 		assertValidationErrors(
 			file,
 			GTPackage.eINSTANCE.editorReference,
-			Diagnostic::LINKING_DIAGNOSTIC,
-			"Couldn't resolve reference to EReference 'name'."
+			GTLinkingDiagnosticMessageProvider.REFERENCE_NOT_FOUND,
+			String.format(GTLinkingDiagnosticMessageProvider.REFERENCE_NOT_FOUND_MESSAGE, 'eClassifiers')
 		)
 	}
 

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
@@ -15,6 +15,9 @@ import org.emoflon.ibex.gt.editor.gT.EditorAttribute
 class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvider {
 	private static val CODE_PREFIX = "org.emoflon.ibex.gt.editor."
 
+	public static val ATTRIBUTE_NOT_FOUND = CODE_PREFIX + "attribute.type.notFound"
+	public static val ATTRIBUTE_NOT_FOUND_MESSAGE = "Could not find attribute '%s'."
+
 	public static val ATTRIBUTE_EXPRESSION_NODE_NOT_FOUND = CODE_PREFIX + "attributeExpression.node.notFound"
 	public static val ATTRIBUTE_EXPRESSION_NODE_NOT_FOUND_MESSAGE = "Could not find node '%s'."
 
@@ -36,6 +39,15 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 			linkText = context.getLinkText();
 		} catch (IllegalNodeException e) {
 			linkText = e.getNode().getText();
+		}
+
+		// Attribute not found.
+		if (context.reference === GTPackage.Literals.EDITOR_ATTRIBUTE__ATTRIBUTE) {
+			return new DiagnosticMessage(
+				String.format(ATTRIBUTE_NOT_FOUND_MESSAGE, linkText),
+				Severity.ERROR,
+				ATTRIBUTE_NOT_FOUND
+			)
 		}
 
 		// Node of attribute expression not found.

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
@@ -30,6 +30,9 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 	public static val PARAMETER_EXPRESSION_PARAMETER_NOT_FOUND = CODE_PREFIX + "parameterExpression.parameter.notFound"
 	public static val PARAMETER_EXPRESSION_PARAMETER_NOT_FOUND_MESSAGE = "Could not find parameter '%s' of type '%s'."
 
+	public static val REFERENCE_NOT_FOUND = CODE_PREFIX + "reference.type.notFound"
+	public static val REFERENCE_NOT_FOUND_MESSAGE = "Could not find reference '%s'."
+
 	public static val REFERENCE_TARGET_NODE_NOT_FOUND = CODE_PREFIX + "reference.target.nodeNotFound"
 	public static val REFERENCE_TARGET_NODE_NOT_FOUND_MESSAGE = "Could not find node '%s' of type '%s'."
 
@@ -87,9 +90,18 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 			)
 		}
 
-		// Node for reference target not found in scope.
+		// Reference type not found.
+		if (context.reference === GTPackage.Literals.EDITOR_REFERENCE__TYPE) {
+			return new DiagnosticMessage(
+				String.format(REFERENCE_NOT_FOUND_MESSAGE, linkText),
+				Severity.ERROR,
+				REFERENCE_NOT_FOUND
+			)
+		}
+
+		// Reference target node not found in scope.
 		if (context.reference === GTPackage.Literals.EDITOR_REFERENCE__TARGET) {
-			val expectedType = (context.context as EditorReference).type.EReferenceType.name
+			val expectedType = (context.context as EditorReference).type?.EReferenceType?.name
 			return new DiagnosticMessage(
 				String.format(REFERENCE_TARGET_NODE_NOT_FOUND_MESSAGE, linkText, expectedType),
 				Severity.ERROR,

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTLinkingDiagnosticMessageProvider.xtend
@@ -18,6 +18,9 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 	public static val ATTRIBUTE_NOT_FOUND = CODE_PREFIX + "attribute.type.notFound"
 	public static val ATTRIBUTE_NOT_FOUND_MESSAGE = "Could not find attribute '%s'."
 
+	public static val ATTRIBUTE_EXPRESSION_ATTRIBUTE_NOT_FOUND = CODE_PREFIX + "attributeExpression.attribute.notFound"
+	public static val ATTRIBUTE_EXPRESSION_ATTRIBUTE_NOT_FOUND_MESSAGE = "Could not find attribute '%s'."
+
 	public static val ATTRIBUTE_EXPRESSION_NODE_NOT_FOUND = CODE_PREFIX + "attributeExpression.node.notFound"
 	public static val ATTRIBUTE_EXPRESSION_NODE_NOT_FOUND_MESSAGE = "Could not find node '%s'."
 
@@ -50,6 +53,15 @@ class GTLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessageProvide
 				String.format(ATTRIBUTE_NOT_FOUND_MESSAGE, linkText),
 				Severity.ERROR,
 				ATTRIBUTE_NOT_FOUND
+			)
+		}
+
+		// Attribute type of attribute expression not found.
+		if (context.reference === GTPackage.Literals.EDITOR_ATTRIBUTE_EXPRESSION__ATTRIBUTE) {
+			return new DiagnosticMessage(
+				String.format(ATTRIBUTE_EXPRESSION_ATTRIBUTE_NOT_FOUND_MESSAGE, linkText),
+				Severity.ERROR,
+				ATTRIBUTE_EXPRESSION_ATTRIBUTE_NOT_FOUND
 			)
 		}
 

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTScopeProvider.xtend
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/scoping/GTScopeProvider.xtend
@@ -180,26 +180,20 @@ class GTScopeProvider extends AbstractGTScopeProvider {
 	 */
 	def getScopeForReferenceTargets(EditorReference reference) {
 		val referenceType = reference.type
+		val pattern = reference.eContainer.eContainer as EditorPattern
+
 		if (referenceType !== null) {
 			val targetNodeType = referenceType.EReferenceType
 			if (targetNodeType !== null) {
-				val pattern = reference.eContainer.eContainer as EditorPattern
-				if (pattern !== null) {
-					val nodes = GTEditorPatternUtils.getAllNodesOfPattern(pattern, [
-						isNodeOfType(it, targetNodeType)
-					])
-					return Scopes.scopeFor(nodes)
-				}
+				val nodes = GTEditorPatternUtils.getAllNodesOfPattern(pattern, [
+					isNodeOfType(it, targetNodeType)
+				])
+				return Scopes.scopeFor(nodes)
 			}
 		}
-		return Scopes.scopeFor([])
-	}
 
-	/**
-	 * Filters the nodes of the given pattern for the ones with the given type.
-	 */
-	def static filterNodesWithType(EditorPattern pattern, EClass nodeType) {
-		pattern.nodes.filter[isNodeOfType(it, nodeType)].toList
+		// If the type cannot be resolved return all nodes.
+		return Scopes.scopeFor(GTEditorPatternUtils.getAllNodesOfPattern(pattern, [true]))
 	}
 
 	/**

--- a/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/utils/GTCommentExtractor.java
+++ b/org.emoflon.ibex.gt.editor/src/org/emoflon/ibex/gt/editor/utils/GTCommentExtractor.java
@@ -41,7 +41,10 @@ public class GTCommentExtractor {
 				documentation.append(extract(i.getText()));
 			}
 		});
-		return documentation.toString().trim();
+		return documentation.toString() //
+				.replaceAll("\r", "").replaceAll("\n", "") // remove line breaks
+				.replace("  ", " ") // remove multiple consecutive spaces
+				.trim();
 	}
 
 	/**


### PR DESCRIPTION
- Customize error for scoping errors.
- Fix scoping for node target of reference whose type is invalid -> avoid Exception.
- Extract comments as a String without line breaks