### PR TITLE
Added possibility of selecting metamodels in the new project wizard

### DIFF
--- a/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/AbstractMoflonMetaModelSelectionPage.java
+++ b/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/AbstractMoflonMetaModelSelectionPage.java
@@ -1,0 +1,184 @@
+package org.moflon.tgg.mosl.ui.wizards;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.eclipse.emf.ecore.provider.EcoreEditPlugin;
+import org.eclipse.emf.edit.ui.provider.ExtendedImageRegistry;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.xtext.ui.editor.outline.quickoutline.StringMatcher;
+
+public abstract class AbstractMoflonMetaModelSelectionPage extends WizardPage {
+	protected String message;
+	protected Label label;
+	protected Text textField;
+	protected TableViewer tableViewer;
+	protected ViewerFilter filter;
+	protected String filterPattern;
+	protected Object[] selectedMetaModels;
+
+	public AbstractMoflonMetaModelSelectionPage(String name, String title, String desc, String message) {
+		super(name);
+		this.message = message;
+		filterPattern = "*";
+		// Set information on the page
+		setTitle(title);
+		setDescription(desc);
+		setImageDescriptor(AbstractMoflonWizard.getImage("resources/icons/metamodelProjectWizard.gif"));
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		Composite container = new Composite(parent, SWT.NONE);
+		GridLayout layout1 = new GridLayout();
+		container.setLayout(layout1);
+		label = new Label(container, SWT.NONE);
+		textField = new Text(container, SWT.BORDER | SWT.SINGLE);
+		final GridData gd1 = new GridData();
+		gd1.verticalAlignment = GridData.FILL;
+		gd1.heightHint = 300;
+		gd1.horizontalAlignment = GridData.FILL;
+		gd1.grabExcessHorizontalSpace = true;
+		gd1.grabExcessVerticalSpace = true;
+		final GridData gd2 = new GridData();
+		gd2.verticalAlignment = GridData.FILL;
+		gd2.horizontalAlignment = GridData.FILL;
+		gd2.heightHint = 15;
+		gd2.grabExcessHorizontalSpace = true;
+		gd2.grabExcessVerticalSpace = false;
+		label.setLayoutData(gd2);
+		textField.setLayoutData(gd2);
+		// Place cursor in textfield
+		textField.setFocus();
+		Composite listContainer = new Composite(container, SWT.NONE);
+		FillLayout layout2 = new FillLayout(SWT.VERTICAL);
+		listContainer.setLayout(layout2);
+		listContainer.setLayoutData(gd1);
+		label.setText(message);
+		tableViewer = new TableViewer(listContainer);
+		filter = new ViewerFilter() {
+
+			@Override
+			public boolean select(Viewer viewer, Object parentElement, Object element) {
+				if (element == null) {
+					return false;
+				}
+				String modelUri = element.toString();
+				StringMatcher filterMatcher = new StringMatcher(filterPattern, true);
+				return filterMatcher.match(modelUri);
+			}
+		};
+
+		initTextField();
+		initTableViewer();
+
+		// set control
+		setControl(container);
+		setPageComplete(false);
+	}
+
+	protected void initTableViewer() {
+		tableViewer.setLabelProvider(new LabelProvider() {
+			@Override
+			public Image getImage(Object element) {
+				return ExtendedImageRegistry.getInstance()
+						.getImage(EcoreEditPlugin.INSTANCE.getImage("full/obj16/EPackage"));
+			}
+		});
+
+		tableViewer.setContentProvider(new IStructuredContentProvider() {
+			@Override
+			public Object[] getElements(Object inputElement) {
+				return (Object[]) inputElement;
+			}
+		});
+
+		tableViewer.addSelectionChangedListener(new ISelectionChangedListener() {
+
+			@Override
+			public void selectionChanged(SelectionChangedEvent event) {
+				IStructuredSelection selection = (IStructuredSelection) event.getSelection();
+				selectedMetaModels = selection.toArray();
+				if (selectedMetaModels == null || selectedMetaModels.length < 1) {
+					return;
+				}
+
+				setPageComplete(true);
+			}
+		});
+
+		Map<String, URI> ePackageNsURItoGenModelLocationMap = EcorePlugin.getEPackageNsURIToGenModelLocationMap(true);
+		Object[] result = ePackageNsURItoGenModelLocationMap.keySet()
+				.toArray(new Object[ePackageNsURItoGenModelLocationMap.size()]);
+		Arrays.sort(result);
+
+		tableViewer.setInput(result);
+		tableViewer.addFilter(filter);
+	}
+
+	protected void initTextField() {
+		textField.setText("*");
+		textField.addModifyListener(new ModifyListener() {
+
+			@Override
+			public void modifyText(ModifyEvent e) {
+				Text t = (Text) (e.widget);
+				if (!t.isFocusControl()) {
+					return;
+				}
+
+				else {
+					String text = t.getText();
+					if (text.length() > 0) {
+						filterPattern = text;
+						tableViewer.resetFilters();
+						tableViewer.addFilter(filter);
+					}
+				}
+
+			}
+		});
+	}
+
+	@Override
+	public void setVisible(final boolean visible) {
+		super.setVisible(visible);
+		// Place cursor in textfield
+		textField.setFocus();
+
+		// Reset selection and filter pattern
+		if (selectedMetaModels == null) {
+			textField.setText("*");
+			tableViewer.resetFilters();
+			tableViewer.getTable().deselectAll();
+		}
+	}
+
+	public Object[] getSelectedMetaModels() {
+		return selectedMetaModels;
+	}
+
+	public void setSelectedMetaModels(Object[] selectedMetaModels) {
+		this.selectedMetaModels = selectedMetaModels;
+	}
+}

--- a/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationProjectInfoPage.java
+++ b/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationProjectInfoPage.java
@@ -3,7 +3,7 @@ package org.moflon.tgg.mosl.ui.wizards;
 public class NewIntegrationProjectInfoPage extends AbstractMoflonProjectInfoPage {
 
 	public NewIntegrationProjectInfoPage() {
-		super("NewIntegrationProjectInfo", "New TGG Project",
-				"This wizard creates a new eMoflon TGG Project.");
+		super("NewIntegrationProjectInfo", "New TGG Project", "This wizard creates a new eMoflon TGG Project");
 	}
+
 }

--- a/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationProjectSrcModelSelectionPage.java
+++ b/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationProjectSrcModelSelectionPage.java
@@ -1,0 +1,9 @@
+package org.moflon.tgg.mosl.ui.wizards;
+
+public class NewIntegrationProjectSrcModelSelectionPage extends AbstractMoflonMetaModelSelectionPage {
+
+	public NewIntegrationProjectSrcModelSelectionPage() {
+		super("NewIntegrationProjectSrcModelSelection", "New TGG Project", "Selection of source metamodels", "Select source metamodels:");
+	}
+
+}

--- a/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationProjectTrgModelSelectionPage.java
+++ b/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationProjectTrgModelSelectionPage.java
@@ -1,0 +1,9 @@
+package org.moflon.tgg.mosl.ui.wizards;
+
+public class NewIntegrationProjectTrgModelSelectionPage extends AbstractMoflonMetaModelSelectionPage {
+
+	public NewIntegrationProjectTrgModelSelectionPage() {
+		super("NewIntegrationProjectTrgModelSelection", "New TGG Project", "Selection of target metamodels", "Select target metamodels:");
+	}
+
+}

--- a/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationWizard.java
+++ b/org.emoflon.ibex.tgg.editor.ui/src/org/moflon/tgg/mosl/ui/wizards/NewIntegrationWizard.java
@@ -1,6 +1,14 @@
 package org.moflon.tgg.mosl.ui.wizards;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
@@ -10,6 +18,16 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.INewWizard;
 import org.emoflon.ibex.tgg.ide.admin.IbexTGGNature;
 import org.moflon.core.utilities.LogUtils;
@@ -18,8 +36,16 @@ import org.moflon.core.utilities.WorkspaceHelper;
 import org.moflon.tgg.mosl.defaults.AttrCondDefLibraryProvider;
 import org.moflon.tgg.mosl.defaults.DefaultFilesHelper;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 public class NewIntegrationWizard extends AbstractMoflonWizard implements INewWizard {
 	protected AbstractMoflonProjectInfoPage projectInfo;
+	protected AbstractMoflonMetaModelSelectionPage srcSelection;
+	protected AbstractMoflonMetaModelSelectionPage trgSelection;
+	protected Set<String> importURIs;
+	protected List<String> sourceMetamodelsNames;
+	protected List<String> targetMetamodelsNames;
 
 	private static final Logger logger = Logger.getLogger(NewIntegrationWizard.class);
 
@@ -27,25 +53,44 @@ public class NewIntegrationWizard extends AbstractMoflonWizard implements INewWi
 
 	@Override
 	public void addPages() {
+		importURIs = Sets.newHashSet();
+		sourceMetamodelsNames = new ArrayList<String>();
+		targetMetamodelsNames = new ArrayList<String>();
 		projectInfo = new NewIntegrationProjectInfoPage();
+		srcSelection = new NewIntegrationProjectSrcModelSelectionPage();
+		trgSelection = new NewIntegrationProjectTrgModelSelectionPage();
 		addPage(projectInfo);
+		addPage(srcSelection);
+		addPage(trgSelection);
+	}
+
+	@Override
+	public IWizardPage getNextPage(IWizardPage currentPage) {
+		if (currentPage == projectInfo && projectInfo.isSelectMetaModels()) {
+			return srcSelection;
+		} else if (currentPage == srcSelection) {
+			return trgSelection;
+		}
+
+		return null;
 	}
 
 	protected void createProject(IProgressMonitor monitor, IProject project) throws CoreException {
 		final SubMonitor subMon = SubMonitor.convert(monitor, "Creating " + project.getName(), 3);
-		
+
 		// Create project
 		project.create(subMon.split(1));
 		project.open(subMon.split(1));
-		
+
 		// Add Ibex TGG Nature
-		WorkspaceHelper.addNature(project, IbexTGGNature.IBEX_TGG_NATURE_ID, subMon.split(1)); 
+		WorkspaceHelper.addNature(project, IbexTGGNature.IBEX_TGG_NATURE_ID, subMon.split(1));
 	}
 
 	protected void generateDefaultFiles(final IProgressMonitor monitor, IProject project) throws CoreException {
 		try {
 			final SubMonitor subMon = SubMonitor.convert(monitor, "Generating default files", 3);
-			String defaultSchema = DefaultFilesHelper.generateDefaultSchema(MoflonUtil.lastCapitalizedSegmentOf(project.getName()));
+			String defaultSchema = DefaultFilesHelper.generateDefaultSchema(MoflonUtil.lastCapitalizedSegmentOf(project.getName()),
+					Lists.newArrayList(importURIs), sourceMetamodelsNames, targetMetamodelsNames);
 			IPath pathToSchema = new Path(IbexTGGNature.SCHEMA_FILE);
 			WorkspaceHelper.addAllFoldersAndFile(project, pathToSchema, defaultSchema, subMon.split(1));
 			WorkspaceHelper.addAllFolders(project, "src/org/emoflon/ibex/tgg/rules", subMon.split(1));
@@ -56,14 +101,87 @@ public class NewIntegrationWizard extends AbstractMoflonWizard implements INewWi
 		}
 	}
 
+	private void getMetamodelURIs(IProgressMonitor monitor, Object[] selectedPackages, boolean isSource) {
+		final SubMonitor subMon = SubMonitor.convert(monitor, "Getting metamodel URIs", 3);
+		if (selectedPackages != null) {
+			List<?> nsURIs = Arrays.asList(selectedPackages);
+			ResourceSet resourceSet = new ResourceSetImpl();
+			resourceSet.getURIConverter().getURIMap().putAll(EcorePlugin.computePlatformURIMap(true));
+
+			Map<String, URI> ePackageNsURItoGenModelLocationMapEnv = EcorePlugin
+					.getEPackageNsURIToGenModelLocationMap(false);
+			Map<String, URI> ePackageNsURItoGenModelLocationMapTrg = EcorePlugin
+					.getEPackageNsURIToGenModelLocationMap(true);
+			for (int i = 0, length = selectedPackages.length; i < length; i++) {
+				URI location = ePackageNsURItoGenModelLocationMapEnv.get(selectedPackages[i]);
+				if (location == null) {
+					location = ePackageNsURItoGenModelLocationMapTrg.get(selectedPackages[i]);
+				}
+				if (location == null) {
+					LogUtils.error(logger, "Package with URI %s not found", selectedPackages[i].toString());
+					continue;
+				}
+				try {
+					Resource resource = resourceSet.getResource(location, true);
+					EcoreUtil.resolveAll(resource);
+				} catch (RuntimeException e) {
+					LogUtils.error(logger, "Error while loading resource with URI: %s", location.toString());
+				}
+
+			}
+
+			subMon.worked(1);
+
+			List<Resource> resources = resourceSet.getResources();
+
+			for (Resource resource : resources) {
+				for (EPackage ePackage : getAllPackages(resource)) {
+					if (nsURIs.contains(ePackage.getNsURI())) {
+						if (isSource)
+							sourceMetamodelsNames.add(ePackage.getName());
+						else
+							targetMetamodelsNames.add(ePackage.getName());
+						importURIs.add(resource.getURI().toString());
+						break;
+					}
+				}
+			}
+
+			subMon.worked(2);
+		}
+
+		subMon.setWorkRemaining(0);
+	}
+
+	private Collection<EPackage> getAllPackages(Resource resource) {
+		List<EPackage> result = new ArrayList<EPackage>();
+		for (TreeIterator<?> j = new EcoreUtil.ContentTreeIterator<Object>(resource.getContents()) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected Iterator<? extends EObject> getEObjectChildren(EObject eObject) {
+				return eObject instanceof EPackage ? ((EPackage) eObject).getESubpackages().iterator()
+						: Collections.<EObject>emptyList().iterator();
+			}
+		};j.hasNext();) {
+			Object content = j.next();
+			if (content instanceof EPackage) {
+				result.add((EPackage) content);
+			}
+		}
+		return result;
+	}
+
 	@Override
 	protected void doFinish(final IProgressMonitor monitor) throws CoreException {
 		try {
-			final SubMonitor subMon = SubMonitor.convert(monitor, "Creating eMoflon::Ibex project", 6);
+			final SubMonitor subMon = SubMonitor.convert(monitor, "Creating eMoflon::Ibex project", 12);
 
 			String projectName = projectInfo.getProjectName();
 			IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 			createProject(subMon.split(3), project);
+			getMetamodelURIs(subMon.split(3), srcSelection.getSelectedMetaModels(), true);
+			getMetamodelURIs(subMon.split(3), trgSelection.getSelectedMetaModels(), false);
 			generateDefaultFiles(subMon.split(3), project);
 		} catch (Exception e) {
 			LogUtils.error(logger, e);

--- a/org.emoflon.ibex.tgg.editor/src/org/moflon/tgg/mosl/defaults/DefaultFilesHelper.xtend
+++ b/org.emoflon.ibex.tgg.editor/src/org/moflon/tgg/mosl/defaults/DefaultFilesHelper.xtend
@@ -1,19 +1,51 @@
 package org.moflon.tgg.mosl.defaults
 
-class DefaultFilesHelper {
+import java.util.List
 
-	static def generateDefaultSchema(String projectName) {
+class DefaultFilesHelper {
+	
+	private static def concatAndFormatMetamodelNameList(List<String> metamodelNames) {
+		val StringBuilder sb = new StringBuilder();
+		if(metamodelNames == null || metamodelNames.size() == 0) {
+			return sb.toString();
+		}
+		
+		for(String name : metamodelNames) {
+			sb.append(name);
+			sb.append(System.lineSeparator());
+		}
+		return sb.toString();
+	}
+
+	static def generateDefaultSchema(String projectName, List<String> importURIs, List<String> sourceMetamodels,
+		List<String> targetMetamodels) {
+		var String importSection = "// Add imports here" + System.lineSeparator();
+		if (importURIs != null && importURIs.size() > 0) {
+			val StringBuilder sb = new StringBuilder();
+			for (String modelURI : importURIs) {
+				sb.append("#import \"");
+				sb.append(modelURI);
+				sb.append("\"")
+				sb.append(System.lineSeparator());
+			}
+
+			importSection = sb.toString();
+		}
+		
+		val String sourceSection = concatAndFormatMetamodelNameList(sourceMetamodels);
+		val String targetSection = concatAndFormatMetamodelNameList(targetMetamodels);
+
 		return '''
-			// Add imports here
+			«importSection»
 			
 			#schema «projectName»
 				
 			#source {
-				
+				«sourceSection»
 			}
 			
 			#target { 
-				
+				«targetSection»
 			} 
 			
 			#correspondence {

--- a/org.emoflon.ibex.tgg.editor/src/org/moflon/tgg/mosl/formatting2/TGGFormatter.xtend
+++ b/org.emoflon.ibex.tgg.editor/src/org/moflon/tgg/mosl/formatting2/TGGFormatter.xtend
@@ -30,6 +30,7 @@ import org.moflon.tgg.mosl.tgg.TripleGraphGrammarFile
 import org.moflon.tgg.mosl.tgg.Using
 
 import static org.moflon.tgg.mosl.tgg.TggPackage.Literals.*
+import org.moflon.tgg.mosl.tgg.ComplementRule
 
 class TGGFormatter extends AbstractFormatter2 {
 
@@ -42,6 +43,7 @@ class TGGFormatter extends AbstractFormatter2 {
     val srcArrowKW	= "#src->"
     val trgArrowKW 	= "#trg->"
     val ruleKW		= "#rule"
+    val cmplRuleW	= "#complement"
     val syncKW 		= "#sync:"
     val genKW 		= "#gen:"
     val arrowKW		= "->"
@@ -83,6 +85,9 @@ class TGGFormatter extends AbstractFormatter2 {
 		format(triplegraphgrammarfile.getSchema(), document);
 		for (Rule rules : triplegraphgrammarfile.getRules()) {
 			format(rules, document);
+		}
+		for (ComplementRule cmplRules : triplegraphgrammarfile.getComplementRules()) {
+			format(cmplRules, document);
 		}
 		format(triplegraphgrammarfile.library, document);
 	}
@@ -160,6 +165,38 @@ class TGGFormatter extends AbstractFormatter2 {
 		
 		lineSeparator(rule.attrConditions,document)
 		for (AttrCond attrConditions : rule.getAttrConditions()) {
+			format(attrConditions, document);
+		}
+		
+	}
+	
+	def dispatch void format(ComplementRule cmplRule, extension IFormattableDocument document) {
+		cmplRule.append[newLines = 3]
+		cmplRule.regionFor.keyword(cmplRuleW).prepend[setNewLines(2);highPriority]
+		cmplRule.regionFor.keyword(sourceKW).prepend[setNewLines(2)]
+		cmplRule.regionFor.keyword(targetKW).prepend[setNewLines(2)]
+		cmplRule.regionFor.keyword(corrKW).prepend[setNewLines(2)]
+		cmplRule.regionFor.keyword(attrCondsKW).prepend[setNewLines(2)]
+		cmplRule.regionFor.keyword(",").prepend[noSpace]
+	
+		
+		lineSeparator(cmplRule.sourcePatterns, document)
+		for (ObjectVariablePattern sourcePatterns : cmplRule.getSourcePatterns()) {
+			format(sourcePatterns, document);
+		}
+		
+		lineSeparator(cmplRule.targetPatterns, document)
+		for (ObjectVariablePattern targetPatterns : cmplRule.getTargetPatterns()) {
+			format(targetPatterns, document);
+		}
+		
+		lineSeparator(cmplRule.correspondencePatterns,document)
+		for (CorrVariablePattern correspondencePatterns : cmplRule.getCorrespondencePatterns()) {
+			format(correspondencePatterns, document);
+		}
+		
+		lineSeparator(cmplRule.attrConditions,document)
+		for (AttrCond attrConditions : cmplRule.getAttrConditions()) {
 			format(attrConditions, document);
 		}
 		


### PR DESCRIPTION
- The user can now select the metamodels for source and target in the NewIntegrationProjectWizard. If this is not wanted, it is still possible to create a project with a blank schema (no imports).
- The URIs of the selected metamodels are resolved and automatically written in the new project's schema.