### PR TITLE
Fixes redundant MWE2 stub generation by adding empty stub files (possibility 1)

### DIFF
--- a/org.emoflon.ibex.tgg.editor.ui/xtend-src/org/moflon/tgg/mosl/ui/TGGUiModule.java
+++ b/org.emoflon.ibex.tgg.editor.ui/xtend-src/org/moflon/tgg/mosl/ui/TGGUiModule.java
@@ -1,0 +1,1 @@
+// Keep this file to prevent Xtext to re-generate it with a stub.

--- a/org.emoflon.ibex.tgg.editor/xtend-src/org/moflon/tgg/mosl/TGGRuntimeModule.java
+++ b/org.emoflon.ibex.tgg.editor/xtend-src/org/moflon/tgg/mosl/TGGRuntimeModule.java
@@ -1,0 +1,1 @@
+// Keep this file to prevent Xtext to re-generate it with a stub.

--- a/org.emoflon.ibex.tgg.editor/xtend-src/org/moflon/tgg/mosl/TGGStandaloneSetup.java
+++ b/org.emoflon.ibex.tgg.editor/xtend-src/org/moflon/tgg/mosl/TGGStandaloneSetup.java
@@ -1,0 +1,1 @@
+// Keep this file to prevent Xtext to re-generate it with a stub.


### PR DESCRIPTION
Most basic fix: Adds the three "missing" stubs with no content
... to prevent Xtext auto generation.

Closes #204.