### PR TITLE
Fixes tiny eMoflon toolbar buttons in the deployed version

### DIFF
--- a/org.emoflon.ibex.tgg.editor.ui/build.properties
+++ b/org.emoflon.ibex.tgg.editor.ui/build.properties
@@ -3,5 +3,6 @@ source.. = src/,\
            xtend-gen/
 bin.includes = .,\
                META-INF/,\
-               plugin.xml
+               plugin.xml,\
+               resources/
 bin.excludes = **/*.xtend


### PR DESCRIPTION
The resource folder containing the two most right TGG button images was missing in the binary export of the `org.emoflon.ibex.tgg.editor.ui` project.

The bug was introduced when removing the old TGG xtext project and adding the new one:
- Removal: https://github.com/eMoflon/emoflon-ibex-ui/commit/b62d8aaa49fe85dab0cf6515123bec92cb76cf18#diff-290cc8f1060bb8baaad3e2d87c489846b3e0b6c216b5429d499e010b7433ab85
- Addition: https://github.com/eMoflon/emoflon-ibex-ui/commit/8e6c31de63ab8a3627f1cc7117b7bd09f73975d6#diff-c82b1b39055203197430ea52794f67c156b74c2e61eb9fc9dc1f80661548cd57

Closes https://github.com/eMoflon/emoflon-ibex/issues/411.