### PR TITLE
Fixes broken TGG-Integrate on Xtext v2.32.0/Eclipse 2023-09 + Removes org.apache.commons.io/org.apache.commons.commons-io external dependency

### DIFF
--- a/org.emoflon.ibex.tgg.editor/src/org/emoflon/ibex/tgg/editor/defaults/AttrCondDefLibraryProvider.java
+++ b/org.emoflon.ibex.tgg.editor/src/org/emoflon/ibex/tgg/editor/defaults/AttrCondDefLibraryProvider.java
@@ -2,8 +2,8 @@ package org.emoflon.ibex.tgg.editor.defaults;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -22,8 +22,7 @@ public class AttrCondDefLibraryProvider {
 		IPath pathToLib = new Path(path);
 		IFile attrLibFile = project.getFile(pathToLib);
 		if (attrLibFile.exists()) {
-			File file = new File(attrLibFile.getLocation().toString());
-			String contents = FileUtils.readFileToString(file, (String) null);
+			String contents = Files.readString(attrLibFile.getLocation().toPath());
 			if (!contents.equals(defaultLib)) {
 				WorkspaceHelper.addAllFoldersAndFile(project, pathToLib, defaultLib, new NullProgressMonitor());
 			}

--- a/org.emoflon.ibex.tgg.integrate/src/org/emoflon/ibex/tgg/integrate/generator/ConflictResolutionSpecificationGenerator.xtend
+++ b/org.emoflon.ibex.tgg.integrate/src/org/emoflon/ibex/tgg/integrate/generator/ConflictResolutionSpecificationGenerator.xtend
@@ -1,6 +1,6 @@
 package org.emoflon.ibex.tgg.integrate.generator
 
-import javax.inject.Inject
+import com.google.inject.Inject;
 import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.naming.QualifiedName
 import org.emoflon.ibex.tgg.operational.strategies.integrate.conflicts.Conflict

--- a/org.emoflon.ibex.tgg.integrate/src/org/emoflon/ibex/tgg/integrate/generator/IntegrateGenerator.xtend
+++ b/org.emoflon.ibex.tgg.integrate/src/org/emoflon/ibex/tgg/integrate/generator/IntegrateGenerator.xtend
@@ -3,7 +3,7 @@
  */
 package org.emoflon.ibex.tgg.integrate.generator
 
-import javax.inject.Inject
+import com.google.inject.Inject;
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.generator.AbstractGenerator
 import org.eclipse.xtext.generator.IFileSystemAccess2


### PR DESCRIPTION
Closes #211.