### PR TITLE
Upgrades TGG and TGG integrate projects to use JUnit v6

### DIFF
--- a/org.emoflon.ibex.tgg.editor/src/org/emoflon/ibex/tgg/editor/GenerateTGG.mwe2
+++ b/org.emoflon.ibex.tgg.editor/src/org/emoflon/ibex/tgg/editor/GenerateTGG.mwe2
@@ -46,7 +46,7 @@ Workflow {
 				generateXtendStub = true
 			}
 			junitSupport = {
-				junitVersion = "5"
+				junitVersion = "6"
 			}
 		}
 	}

--- a/org.emoflon.ibex.tgg.integrate/src/org/emoflon/ibex/tgg/integrate/GenerateIntegrate.mwe2
+++ b/org.emoflon.ibex.tgg.integrate/src/org/emoflon/ibex/tgg/integrate/GenerateIntegrate.mwe2
@@ -48,7 +48,7 @@ Workflow {
 				generateXtendStub = true
 			}
 			junitSupport = {
-				junitVersion = "5"
+				junitVersion = "6"
 			}
 		}
 	}


### PR DESCRIPTION
Upgrades TGG and TGG integrate projects to use JUnit v6
This is required since Xtext v2.43.0.

See:
- https://github.com/eclipse-xtext/xtext/pull/3560
- https://github.com/eclipse-xtext/xtext/issues/3552
- https://github.com/eclipse-xtext/xtext/compare/v2.42.0...v2.43.0